### PR TITLE
ui5-webcomponents-react-card: fix deprecated `rules` and props description

### DIFF
--- a/tutorials/ui5-webcomponents-react-card/ui5-webcomponents-react-card.md
+++ b/tutorials/ui5-webcomponents-react-card/ui5-webcomponents-react-card.md
@@ -181,7 +181,7 @@ And your application like this:
     </Card>
     ```
 
-    We didn't pass a value to `headerInteractive`, because it [defaults to true](https://reactjs.org/docs/jsx-in-depth.html#props-default-to-true) if the value is omitted.
+    We didn't pass a value to `interactive`, because it [defaults to true](https://reactjs.org/docs/jsx-in-depth.html#props-default-to-true) if the value is omitted.
 
 2.  To make the header react to a click, add a function as value to the `onClick` prop.
 


### PR DESCRIPTION
Automatic commit: Move 'ui5-webcomponents-react-card' from QA to Production

Fixes #18695