### PR TITLE
fixes in CAP tutorials

### DIFF
--- a/tutorials/btp-app-create-cap-application/btp-app-create-cap-application.md
+++ b/tutorials/btp-app-create-cap-application/btp-app-create-cap-application.md
@@ -90,7 +90,7 @@ primary_tag: software-product-function>sap-cloud-application-programming-model
 [ACCORDION-END]
 ---
 [ACCORDION-BEGIN [Step 2: ](Add files to the project)]
-1. Open the Finder on Mac or the Explorer on Windows and navigate to the `tutorial` directory created in tutorial [Create a Directory for Development](btp-app-create-directory).
+1. Open the Finder on Mac or the Explorer on Windows and navigate to the `tutorial` directory created in tutorial [Prepare Your Development Environment for CAP](btp-app-prepare-dev-environment-cap).
 
 2. Open the folder `templates` and keep it open as you copy a number of files from there. For this part of the tutorial and others, it's probably best if you place it next to your VS Code instance.
 

--- a/tutorials/btp-app-events-app-setup-s4hc/btp-app-events-app-setup-s4hc.md
+++ b/tutorials/btp-app-events-app-setup-s4hc/btp-app-events-app-setup-s4hc.md
@@ -273,7 +273,7 @@ Now simulate locally business partner creation and update, and see the results:
     > Can't run the `curl` command?
 
     > * If you encounter any errors running the `curl` command, make sure you are using the `Git BASH` command line interpreter, as advised in `Step 2: Command Line Interpreters` in this [tutorial](btp-app-set-up-local-development).
-    > * If you still like to use a different command line interpreter, here is a useful tutorial on how to [Install cURL](iot-cf-install-curl).
+    > * If you still like to use a different command line interpreter, you can use cURL. For MacOS cURL should already be available, for Windows see the instructions on how to install [cURL](https://chocolatey.org/packages/Curl).
 
 
 4. Refresh the page and choose **Go** again. You will see a new risk in the table.

--- a/tutorials/btp-app-launchpad-service-setup/btp-app-launchpad-service-setup.md
+++ b/tutorials/btp-app-launchpad-service-setup/btp-app-launchpad-service-setup.md
@@ -1,7 +1,7 @@
 ---
 author_name: Iwona Hahn
 author_profile: https://github.com/iwonahahn
-title: Prepare Launchpad Service Setup
+title: Prepare SAP Launchpad Service Setup
 description: This tutorial shows you how to add the SAP Launchpad application.
 keywords: cap
 auto_validation: true


### PR DESCRIPTION
Automatic commit: Move 'btp-app-events-app-setup-s4hc', 'btp-app-create-cap-application' from QA to Production