### PR TITLE
ui5-webcomponents-react: fix code snippets of `List` example

### DIFF
--- a/tutorials/ui5-webcomponents-react-dashboard/ui5-webcomponents-react-dashboard.md
+++ b/tutorials/ui5-webcomponents-react-dashboard/ui5-webcomponents-react-dashboard.md
@@ -270,7 +270,7 @@ export function MyApp() {
 }
 ```
 
-### Add a List
+### Add a `List`
 
 
 1. To wrap the `List` add a `Card` (right after the first one).
@@ -323,7 +323,7 @@ export function MyApp() {
 
     First, create two `CustomListItem`s below the completed items.
 
-    ```JavaScript / JSX
+      ```JavaScript / JSX
     <CustomListItem></CustomListItem>
     <CustomListItem></CustomListItem>
     ```
@@ -333,70 +333,70 @@ export function MyApp() {
     To show the progress, add the `ProgressIndicator` as child of the items, with the following props:
 
     - `value`: The value, which indicates the progress
-    - `valueState`: The value-state (color) of the indicator  
+    - `valueState`: The value-state (color) of the indicator
 
-  ```JavaScript / JSX
-  <CustomListItem>
-    <ProgressIndicator value={89} valueState={ValueState.Success} />
-  </CustomListItem>
-  <CustomListItem>
-    <ProgressIndicator value={5} valueState={ValueState.Error} />
-  </CustomListItem>
-  ```
+    ```JavaScript / JSX
+    <CustomListItem>
+      <ProgressIndicator value={89} valueState={ValueState.Success} />
+    </CustomListItem>
+    <CustomListItem>
+      <ProgressIndicator value={5} valueState={ValueState.Error} />
+    </CustomListItem>
+    ```
 
 7. The indicators are displayed as part of the list item, but the title and status of the activities is still missing.
 For this, add two `Text` components above the indicator:
 
-  ```JavaScript / JSX
-  <CustomListItem>
-    <Text>Activity 3</Text>
-    <Text>in progress</Text>
-    <ProgressIndicator value={89} valueState={ValueState.Success} />
-  </CustomListItem>
-  ```
+    ```JavaScript / JSX
+    <CustomListItem>
+      <Text>Activity 3</Text>
+      <Text>in progress</Text>
+      <ProgressIndicator value={89} valueState={ValueState.Success} />
+    </CustomListItem>
+    ```
 
 8. All necessary information are now available in each item, but the formatting looks terrible. Let's fix that by using a flex box:
 
-  ```JavaScript / JSX
-  <CustomListItem>
-    <FlexBox direction={FlexBoxDirection.Column}>
-      <FlexBox justifyContent={FlexBoxJustifyContent.SpaceBetween}>
-        <Text>Activity 3</Text>
-        <Text>in progress</Text>
+    ```JavaScript / JSX
+    <CustomListItem>
+      <FlexBox direction={FlexBoxDirection.Column}>
+        <FlexBox justifyContent={FlexBoxJustifyContent.SpaceBetween}>
+          <Text>Activity 3</Text>
+          <Text>in progress</Text>
+        </FlexBox>
+        <ProgressIndicator value={89} valueState={ValueState.Success} />
       </FlexBox>
-      <ProgressIndicator value={89} valueState={ValueState.Success} />
-    </FlexBox>
-  </CustomListItem>
-  ```
+    </CustomListItem>
+    ```
 
-  > The `FlexBox` implements most of the [`CSS Flexbox`](https://www.w3schools.com/css/css3_flexbox.asp) behavior without being forced to actually use CSS or other styling methods.
+    > The `FlexBox` implements most of the [`CSS Flexbox`](https://www.w3schools.com/css/css3_flexbox.asp) behavior without being forced to actually use CSS or other styling methods.
 
 9. The content of the list item is now aligned correctly, but doesn't apply the correct padding, colors and dimensions. To fix this as well, pass the `style` prop, to use the default [React `inlineStyle` syntax](https://reactjs.org/docs/dom-elements.html):
 
-  ```JavaScript / JSX
-  <CustomListItem>
-    <FlexBox
-      direction={FlexBoxDirection.Column}
-      style={{ width: "100%", ...spacing.sapUiContentPadding }}
-    >
-      <FlexBox justifyContent={FlexBoxJustifyContent.SpaceBetween}>
-        <Text style={{ fontSize: ThemingParameters.sapFontLargeSize }}>
-          Activity 3
-        </Text>
-        <Text style={{ color: ThemingParameters.sapCriticalTextColor }}>
-          in progress
-        </Text>
+    ```JavaScript / JSX
+    <CustomListItem>
+      <FlexBox
+        direction={FlexBoxDirection.Column}
+        style={{ width: "100%", ...spacing.sapUiContentPadding }}
+      >
+        <FlexBox justifyContent={FlexBoxJustifyContent.SpaceBetween}>
+          <Text style={{ fontSize: ThemingParameters.sapFontLargeSize }}>
+            Activity 3
+          </Text>
+          <Text style={{ color: ThemingParameters.sapCriticalTextColor }}>
+            in progress
+          </Text>
+        </FlexBox>
+        <ProgressIndicator
+          value={89}
+          valueState={ValueState.Success}
+          style={{ ...spacing.sapUiTinyMarginTop }}
+        />
       </FlexBox>
-      <ProgressIndicator
-        value={89}
-        valueState={ValueState.Success}
-        style={{ ...spacing.sapUiTinyMarginTop }}
-      />
-    </FlexBox>
-  </CustomListItem>
-  ```
+    </CustomListItem>
+    ```
 
-  > The `ThemingParameters` used for the color of the status text, contain all available theme dependent styles of UI5 Web Components for React. You will find out more about this in [Tutorial 6](ui5-webcomponents-react-styling)
+    > The `ThemingParameters` used for the color of the status text, contain all available theme dependent styles of UI5 Web Components for React. You will find out more about this in [Tutorial 6](ui5-webcomponents-react-styling)
 
 10. Finally, apply the same layout and styles to the content of the second `CustomListItem`.
 

--- a/tutorials/ui5-webcomponents-react-dashboard/ui5-webcomponents-react-dashboard.md
+++ b/tutorials/ui5-webcomponents-react-dashboard/ui5-webcomponents-react-dashboard.md
@@ -323,7 +323,7 @@ export function MyApp() {
 
     First, create two `CustomListItem`s below the completed items.
 
-      ```JavaScript / JSX
+    ```JavaScript / JSX
     <CustomListItem></CustomListItem>
     <CustomListItem></CustomListItem>
     ```


### PR DESCRIPTION
I hope this will fix the issues with the code snippets in step 3 of this [tutorial](https://developers.sap.com/tutorials/ui5-webcomponents-react-dashboard.html).
Unfortunately, I can't test it as neither the [QA instance](https://developers-qa.sap.com/tutorials/ui5-webcomponents-react-dashboard.html) is updated, nor is "Preview as SAP Tutorial" working. With plain markdown everything looks fine.