### PR TITLE
Fixed Hyperlink Formatting Issue

### DIFF
--- a/tutorials/hana-dbx-extension/hana-dbx-extension.md
+++ b/tutorials/hana-dbx-extension/hana-dbx-extension.md
@@ -7,7 +7,7 @@ primary_tag: software-product>sap-hana-cloud
 ---
 
 # Use the SAP HANA Database Explorer Extension
-<!-- description -->  Learn how the [SAP HANA database explorer for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=SAPSE.hana-database-explorer) can be used to connect to both SAP HANA Cloud and on-premise databases, general Visual Studio Code features, how to use the catalog browser, and how to execute SQL queries.  The SAP HANA database explorer for Visual Studio Code extension contains similar functionality to that in the web-based SAP HANA database explorer although not all functionality is available.
+<!-- description -->  Learn how the SAP HANA database explorer for Visual Studio Code extension can be used to connect to both SAP HANA Cloud and on-premise databases, general Visual Studio Code features, how to use the catalog browser, and how to execute SQL queries.  The SAP HANA database explorer for Visual Studio Code extension contains similar functionality to that in the web-based SAP HANA database explorer although not all functionality is available.
 
 
 ## Prerequisites
@@ -27,7 +27,7 @@ primary_tag: software-product>sap-hana-cloud
     
      ![Download Visual Studio Code](downloadVSCode.png)
 
-2. Open Visual Studio Code and install the SAP HANA database explorer extension from the Extensions marketplace. 
+2. Open Visual Studio Code and install the [SAP HANA database explorer for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=SAPSE.hana-database-explorer) from the Extensions Marketplace. 
 
     >For more information about the latest features and version updates to the extension, you can refer to the **CHANGELOG** tab.
 


### PR DESCRIPTION
For the HANA DBX Extension Tutorial: Seems like hyperlinking in the description doesn't work, so I moved the link elsewhere in the tutorial.