### PR TITLE
Rename deprecated CdsService to CqnService

### DIFF
--- a/tutorials/cp-cap-java-custom-handler/cp-cap-java-custom-handler.md
+++ b/tutorials/cp-cap-java-custom-handler/cp-cap-java-custom-handler.md
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Component;
 
 import com.sap.cds.services.cds.CdsCreateEventContext;
 import com.sap.cds.services.cds.CdsReadEventContext;
-import com.sap.cds.services.cds.CdsService;
+import com.sap.cds.services.cds.CqnService;
 import com.sap.cds.services.handler.EventHandler;
 import com.sap.cds.services.handler.annotations.On;
 import com.sap.cds.services.handler.annotations.ServiceName;
@@ -50,13 +50,13 @@ public class AdminService implements EventHandler {
 
     private Map<Object, Map<String, Object>> products = new HashMap<>();
 
-    @On(event = CdsService.EVENT_CREATE, entity = "AdminService.Products")
+    @On(event = CqnService.EVENT_CREATE, entity = "AdminService.Products")
     public void onCreate(CdsCreateEventContext context) {
         context.getCqn().entries().forEach(e -> products.put(e.get("ID"), e));
         context.setResult(context.getCqn().entries());
     }
 
-    @On(event = CdsService.EVENT_READ, entity = "AdminService.Products")
+    @On(event = CqnService.EVENT_READ, entity = "AdminService.Products")
     public void onRead(CdsReadEventContext context) {
         context.setResult(products.values());
     }

--- a/tutorials/cp-cap-java-custom-logic/cp-cap-java-custom-logic.md
+++ b/tutorials/cp-cap-java-custom-logic/cp-cap-java-custom-logic.md
@@ -201,7 +201,7 @@ public class OrdersService implements EventHandler {
         }
     }
 
-    @Before(event = CdsService.EVENT_CREATE, entity = Orders_.CDS_NAME)
+    @Before(event = CqnService.EVENT_CREATE, entity = Orders_.CDS_NAME)
     public void validateBookAndDecreaseStockViaOrders(List<Orders> orders) {
         for (Orders order : orders) {
             if (order.getItems() != null) {
@@ -281,7 +281,7 @@ Next, let's add a method to the `OrdersService` Java class to calculate the `net
 1. Add the following code to the class and make sure you **Save** the file:
 
     ```Java
-    @After(event = { CqnService.EVENT_READ, CdsService.EVENT_CREATE }, entity = OrderItems_.CDS_NAME)
+    @After(event = { CqnService.EVENT_READ, CqnService.EVENT_CREATE }, entity = OrderItems_.CDS_NAME)
     public void calculateNetAmount(List<OrderItems> items) {
         for (OrderItems item : items) {
             String bookId = item.getBookId();
@@ -368,7 +368,7 @@ Finally, add a method to the `OrdersService` Java class to calculate the `total`
 1. Add the following code to the class and make sure you **Save** the file:
 
     ```Java
-    @After(event = { CqnService.EVENT_READ, CdsService.EVENT_CREATE }, entity = Orders_.CDS_NAME)
+    @After(event = { CqnService.EVENT_READ, CqnService.EVENT_CREATE }, entity = Orders_.CDS_NAME)
     public void calculateTotal(List<Orders> orders) {
         for (Orders order : orders) {
             // calculate net amount for expanded items

--- a/tutorials/cp-cap-java-custom-logic/cp-cap-java-custom-logic.md
+++ b/tutorials/cp-cap-java-custom-logic/cp-cap-java-custom-logic.md
@@ -68,7 +68,7 @@ You will now add a method to the `OrdersService` Java class to decrease the stoc
     @Autowired
     PersistenceService db;
 
-    @Before(event = CdsService.EVENT_CREATE, entity = OrderItems_.CDS_NAME)
+    @Before(event = CqnService.EVENT_CREATE, entity = OrderItems_.CDS_NAME)
     public void validateBookAndDecreaseStock(List<OrderItems> items) {
         for (OrderItems item : items) {
             String bookId = item.getBookId();
@@ -92,7 +92,7 @@ You will now add a method to the `OrdersService` Java class to decrease the stoc
         }
     }
 
-    @Before(event = CdsService.EVENT_CREATE, entity = Orders_.CDS_NAME)
+    @Before(event = CqnService.EVENT_CREATE, entity = Orders_.CDS_NAME)
     public void validateBookAndDecreaseStockViaOrders(List<Orders> orders) {
         for (Orders order : orders) {
             if (order.getItems() != null) {
@@ -114,7 +114,7 @@ You will now add a method to the `OrdersService` Java class to decrease the stoc
     import com.sap.cds.ql.cqn.CqnUpdate;
     import com.sap.cds.services.ErrorStatuses;
     import com.sap.cds.services.ServiceException;
-    import com.sap.cds.services.cds.CdsService;
+    import com.sap.cds.services.cds.CqnService;
     import com.sap.cds.services.handler.annotations.Before;
     import com.sap.cds.services.persistence.PersistenceService;
 
@@ -160,7 +160,7 @@ import com.sap.cds.ql.cqn.CqnSelect;
 import com.sap.cds.ql.cqn.CqnUpdate;
 import com.sap.cds.services.ErrorStatuses;
 import com.sap.cds.services.ServiceException;
-import com.sap.cds.services.cds.CdsService;
+import com.sap.cds.services.cds.CqnService;
 import com.sap.cds.services.handler.annotations.Before;
 import com.sap.cds.services.persistence.PersistenceService;
 
@@ -177,7 +177,7 @@ public class OrdersService implements EventHandler {
     @Autowired
     PersistenceService db;
 
-    @Before(event = CdsService.EVENT_CREATE, entity = OrderItems_.CDS_NAME)
+    @Before(event = CqnService.EVENT_CREATE, entity = OrderItems_.CDS_NAME)
     public void validateBookAndDecreaseStock(List<OrderItems> items) {
         for (OrderItems item : items) {
             String bookId = item.getBookId();
@@ -281,7 +281,7 @@ Next, let's add a method to the `OrdersService` Java class to calculate the `net
 1. Add the following code to the class and make sure you **Save** the file:
 
     ```Java
-    @After(event = { CdsService.EVENT_READ, CdsService.EVENT_CREATE }, entity = OrderItems_.CDS_NAME)
+    @After(event = { CqnService.EVENT_READ, CdsService.EVENT_CREATE }, entity = OrderItems_.CDS_NAME)
     public void calculateNetAmount(List<OrderItems> items) {
         for (OrderItems item : items) {
             String bookId = item.getBookId();
@@ -368,7 +368,7 @@ Finally, add a method to the `OrdersService` Java class to calculate the `total`
 1. Add the following code to the class and make sure you **Save** the file:
 
     ```Java
-    @After(event = { CdsService.EVENT_READ, CdsService.EVENT_CREATE }, entity = Orders_.CDS_NAME)
+    @After(event = { CqnService.EVENT_READ, CdsService.EVENT_CREATE }, entity = Orders_.CDS_NAME)
     public void calculateTotal(List<Orders> orders) {
         for (Orders order : orders) {
             // calculate net amount for expanded items

--- a/tutorials/cp-cap-java-service-reuse/cp-cap-java-service-reuse.md
+++ b/tutorials/cp-cap-java-service-reuse/cp-cap-java-service-reuse.md
@@ -41,7 +41,7 @@ From the products service that you created in the previous tutorial, we just wan
 
     ```Shell/Bash
     mvn -B archetype:generate -DarchetypeArtifactId=cds-services-archetype -DarchetypeGroupId=com.sap.cds \
-    -DarchetypeVersion=RELEASE \
+    -DarchetypeVersion=RELEASE -DjdkVersion=11 \
     -DgroupId=com.sap.cap -DartifactId=bookstore
     ```
 


### PR DESCRIPTION
1. Rename deprecated `CdsService` to `CqnService`
As per `cds-services` 1.31.0 changelog:

> CdsService is now marked as deprecated in favor of class CqnService. CdsService is planned to be removed in the next major release to avoid import conflicts with a class with the same name from the Reflection API.

2. Container JDK is 11, however the latest `cds-services` uses JDK 17. Need to explicitly define JDK version 11 when generating archetype.