### PR TITLE
Upgrade paketo builder

### DIFF
--- a/tutorials/btp-app-kyma-deploy-application/btp-app-kyma-deploy-application.md
+++ b/tutorials/btp-app-kyma-deploy-application/btp-app-kyma-deploy-application.md
@@ -111,7 +111,7 @@ CONTAINER_REGISTRY=<your-container-registry>
     ```Shell/Bash
     pack build $CONTAINER_REGISTRY/cpapp-srv --path gen/srv \
     --buildpack gcr.io/paketo-buildpacks/nodejs \
-    --builder paketobuildpacks/builder:base \
+    --builder paketobuildpacks/builder-jammy-base \
     --env BP_NODE_RUN_SCRIPTS=""
     ```
 
@@ -131,7 +131,7 @@ CONTAINER_REGISTRY=<your-container-registry>
     ```Shell/Bash
     pack build $CONTAINER_REGISTRY/cpapp-hana-deployer --path gen/db \
         --buildpack gcr.io/paketo-buildpacks/nodejs \
-        --builder paketobuildpacks/builder:base \
+        --builder paketobuildpacks/builder-jammy-base \
         --env BP_NODE_RUN_SCRIPTS=""
     ```
 

--- a/tutorials/btp-app-kyma-work-zone-setup/btp-app-kyma-work-zone-setup.md
+++ b/tutorials/btp-app-kyma-work-zone-setup/btp-app-kyma-work-zone-setup.md
@@ -329,7 +329,7 @@ The name of your SAP Cloud service (`cpapp` in this case) should be unique withi
          --env BP_NODE_RUN_SCRIPTS=build \
          --path app \
          --buildpack gcr.io/paketo-buildpacks/nodejs \
-         --builder paketobuildpacks/builder:base
+         --builder paketobuildpacks/builder-jammy-base
     ```
 
     The parameter `--env BP_NODE_RUN_SCRIPTS=build` triggers the build script in the `app/package.json`, which runs the UI5 build for the SAP Fiori applications as it is defined in the `app/build.sh` file. The build result appears in the docker image only. It's not on your file system.

--- a/tutorials/deploy-multitenant-app-kyma/deploy-multitenant-app-kyma.md
+++ b/tutorials/deploy-multitenant-app-kyma/deploy-multitenant-app-kyma.md
@@ -68,14 +68,12 @@ brew install buildpacks/tap/pack
 <p> </p>
     In the directory `kyma-multitenant-approuter`, build the image for the approuter app from source, for example:
 ```Shell / Bash
-pack build multitenant-approuter --builder paketobuildpacks/builder-jammy-base
-docker tag multitenant-approuter <docker-hub-account>/multitenant-approuter:v1
+pack build <docker-hub-account>/multitenant-approuter:v1 --builder paketobuildpacks/builder-jammy-base
 ```
 
     In the directory `kyma-multitenant-node`, build the image for the approuter app from source, for example:
 ```Shell / Bash
-pack build multitenant-kyma-backend --builder paketobuildpacks/builder-jammy-base
-docker tag multitenant-kyma-backend <docker-hub-account>/multitenant-kyma-backend:v1
+pack build <docker-hub-account>/multitenant-kyma-backend:v1 --builder paketobuildpacks/builder-jammy-base
 ```
 
 

--- a/tutorials/deploy-multitenant-app-kyma/deploy-multitenant-app-kyma.md
+++ b/tutorials/deploy-multitenant-app-kyma/deploy-multitenant-app-kyma.md
@@ -68,13 +68,13 @@ brew install buildpacks/tap/pack
 <p> </p>
     In the directory `kyma-multitenant-approuter`, build the image for the approuter app from source, for example:
 ```Shell / Bash
-pack build multitenant-approuter --builder paketobuildpacks/builder:full
+pack build multitenant-approuter --builder paketobuildpacks/builder-jammy-base
 docker tag multitenant-approuter <docker-hub-account>/multitenant-approuter:v1
 ```
 
     In the directory `kyma-multitenant-node`, build the image for the approuter app from source, for example:
 ```Shell / Bash
-pack build multitenant-kyma-backend --builder paketobuildpacks/builder:full
+pack build multitenant-kyma-backend --builder paketobuildpacks/builder-jammy-base
 docker tag multitenant-kyma-backend <docker-hub-account>/multitenant-kyma-backend:v1
 ```
 

--- a/tutorials/deploy-nodejs-application-kyma/deploy-nodejs-application-kyma.md
+++ b/tutorials/deploy-nodejs-application-kyma/deploy-nodejs-application-kyma.md
@@ -62,7 +62,7 @@ As you can only create one private repository in a free Docker hub account, Dock
 **2.** In the directory `kyma-multitenant-node`, build the image for the approuter app from source, for example:
 
 ```Shell / Bash
-pack build multitenant-kyma-backend --builder paketobuildpacks/builder:full
+pack build multitenant-kyma-backend --builder paketobuildpacks/builder-jammy-base
 docker tag multitenant-kyma-backend <docker-hub-account>/multitenant-kyma-backend:v1
 ```
 

--- a/tutorials/deploy-nodejs-application-kyma/deploy-nodejs-application-kyma.md
+++ b/tutorials/deploy-nodejs-application-kyma/deploy-nodejs-application-kyma.md
@@ -62,8 +62,7 @@ As you can only create one private repository in a free Docker hub account, Dock
 **2.** In the directory `kyma-multitenant-node`, build the image for the approuter app from source, for example:
 
 ```Shell / Bash
-pack build multitenant-kyma-backend --builder paketobuildpacks/builder-jammy-base
-docker tag multitenant-kyma-backend <docker-hub-account>/multitenant-kyma-backend:v1
+pack build <docker-hub-account>/multitenant-kyma-backend:v1 --builder paketobuildpacks/builder-jammy-base
 ```
 
 


### PR DESCRIPTION
The former used bionic based builder is [deprecated](https://github.com/paketo-buildpacks/rfcs/blob/main/text/0057-bionic-eos.md) since end of May 2023. This PR upgrades to the new Ubuntu Jammy Builder and simplifies the `pack` command by combining building and tagging (as used in other tutorials as well). 

It also switches from the `full` to the `base` builder which is save in the demonstrated cases and leads to quicker results in the end (verified against [SAP-samples/btp-kyma-runtime-multitenancy-tutorial](https://github.com/SAP-samples/btp-kyma-runtime-multitenancy-tutorial)).
