### PR TITLE
chore(btp-terraform): update provider version

### DIFF
--- a/tutorials/btp-terraform-get-started/btp-terraform-get-started.md
+++ b/tutorials/btp-terraform-get-started/btp-terraform-get-started.md
@@ -41,7 +41,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "0.2.0-beta2"
+      version = "0.3.0-beta1"
     }
   }
 }


### PR DESCRIPTION
We're going to release a new provider version this afternoon (0.3.0-beta1), the tutorial should always refer to the latest version.