### PR TITLE
chore(btp-terraform): update provider version to 0.6.0-beta1

### DIFF
--- a/tutorials/btp-terraform-get-started/btp-terraform-get-started.md
+++ b/tutorials/btp-terraform-get-started/btp-terraform-get-started.md
@@ -41,7 +41,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "0.5.0-beta1"
+      version = "0.6.0-beta1"
     }
   }
 }


### PR DESCRIPTION
Updating the tutorial to the latest release: 0.6.0-beta1

https://registry.terraform.io/providers/SAP/btp/latest/docs