### PR TITLE
chore: update Terraform version to GA version

### DIFF
--- a/tutorials/btp-terraform-get-started/btp-terraform-get-started.md
+++ b/tutorials/btp-terraform-get-started/btp-terraform-get-started.md
@@ -39,7 +39,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "1.0.0-rc2"
+      version = "~>1.0.0"
     }
   }
 }


### PR DESCRIPTION
Update of Terraform tutorial to latest version of Terraform provider (i.e. 1.0.0) to ensure that developers make use of the most recent version.