### PR TITLE
Update integration-tests references

### DIFF
--- a/tutorials/cloudsdk-virtual-data-model-odata/cloudsdk-virtual-data-model-odata.md
+++ b/tutorials/cloudsdk-virtual-data-model-odata/cloudsdk-virtual-data-model-odata.md
@@ -4,23 +4,23 @@ author_name: Johannes Schneider
 author_profile: https://github.com/Johannes-Schneider
 auto_validation: true
 time: 30
-tags: [ tutorial>intermediate, software-product>sap-cloud-sdk]
-primary_tag: software-product>sap-cloud-sdk
+tags: [ tutorial>intermediate, products>sap-cloud-sdk]
+primary_tag: products>sap-cloud-sdk
 ---
 
 # Create and Deep Insert with the Virtual Data Model for OData
 <!-- description --> Create and deep insert functionality for OData as supported by the SAP S/4HANA Cloud SDK.
 
 ## Prerequisites
-- [Introduce Resilience to Your Application](s4sdk-resilience)
-- [Connect to OData Service on Cloud Foundry Using SAP Cloud SDK](s4sdk-odata-service-cloud-foundry)
+ - [Introduce Resilience to Your Application](s4sdk-resilience)
+ - [Connect to OData Service on Cloud Foundry Using SAP Cloud SDK](s4sdk-odata-service-cloud-foundry)
 
 > **Please note that the sandbox service does not support testing creating entities, you might have to use an actual S/4 system to try the tutorial out.**
 
 ## You will learn
-- How to build up a complex data structure using the virtual data model
-- How to write deeply nested data to SAP S/4HANA in a single call
-- How to write unit and integration tests for deep insertion
+  - How to build up a complex data structure using the virtual data model
+  - How to write deeply nested data to SAP S/4HANA in a single call
+  - How to write unit and integration tests for deep insertion
 
 ## Intro
 Use advanced features of the [Virtual Data Model for OData](https://sap.github.io/cloud-sdk/docs/java/features/odata/overview).
@@ -235,7 +235,7 @@ Then you can use a tool like Postman or Curl to check whether the code works. As
 
 Let's write an integration test to test the newly introduced create functionality.
 
-The file needs to be put under your `<projectroot>/integration-tests/src/test/java/com/sap/cloud/sdk/tutorial` directory.
+The file needs to be put under your `<projectroot>/application/src/test/java/com/sap/cloud/sdk/tutorial` directory.
 
 ```Java
 package com.sap.cloud.sdk.tutorial;

--- a/tutorials/cloudsdk-virtual-data-model-odata/cloudsdk-virtual-data-model-odata.md
+++ b/tutorials/cloudsdk-virtual-data-model-odata/cloudsdk-virtual-data-model-odata.md
@@ -12,15 +12,15 @@ primary_tag: products>sap-cloud-sdk
 <!-- description --> Create and deep insert functionality for OData as supported by the SAP S/4HANA Cloud SDK.
 
 ## Prerequisites
- - [Introduce Resilience to Your Application](s4sdk-resilience)
- - [Connect to OData Service on Cloud Foundry Using SAP Cloud SDK](s4sdk-odata-service-cloud-foundry)
+- [Introduce Resilience to Your Application](s4sdk-resilience)
+- [Connect to OData Service on Cloud Foundry Using SAP Cloud SDK](s4sdk-odata-service-cloud-foundry)
 
 > **Please note that the sandbox service does not support testing creating entities, you might have to use an actual S/4 system to try the tutorial out.**
 
 ## You will learn
-  - How to build up a complex data structure using the virtual data model
-  - How to write deeply nested data to SAP S/4HANA in a single call
-  - How to write unit and integration tests for deep insertion
+- How to build up a complex data structure using the virtual data model
+- How to write deeply nested data to SAP S/4HANA in a single call
+- How to write unit and integration tests for deep insertion
 
 ## Intro
 Use advanced features of the [Virtual Data Model for OData](https://sap.github.io/cloud-sdk/docs/java/features/odata/overview).

--- a/tutorials/s4sdk-caching/s4sdk-caching.md
+++ b/tutorials/s4sdk-caching/s4sdk-caching.md
@@ -102,7 +102,7 @@ Let's adapt the test and check what happens when the OData service is not availa
 
 Replace the `testService` test with `testServiceWithCache()` code below:
 
-`integration-tests/src/test/java/com/sap/cloud/sdk/tutorial/BusinessPartnerControllerTest.java`:
+`application/src/test/java/com/sap/cloud/sdk/tutorial/BusinessPartnerControllerTest.java`:
 
 ```Java
 @Test

--- a/tutorials/s4sdk-cloud-foundry-sample-application/s4sdk-cloud-foundry-sample-application.md
+++ b/tutorials/s4sdk-cloud-foundry-sample-application/s4sdk-cloud-foundry-sample-application.md
@@ -46,7 +46,7 @@ In order to deploy applications on `SAP Cloud Foundry` you need to provide the C
 
 Now enter the following commands (in this case for the US region):
 
-```bash!!!!
+```bash
 cf api https://api.cf.us10-001.hana.ondemand.com
 cf login
 ```

--- a/tutorials/s4sdk-cloud-foundry-sample-application/s4sdk-cloud-foundry-sample-application.md
+++ b/tutorials/s4sdk-cloud-foundry-sample-application/s4sdk-cloud-foundry-sample-application.md
@@ -46,7 +46,7 @@ In order to deploy applications on `SAP Cloud Foundry` you need to provide the C
 
 Now enter the following commands (in this case for the US region):
 
-```bash
+```bash!!!!
 cf api https://api.cf.us10-001.hana.ondemand.com
 cf login
 ```
@@ -101,16 +101,11 @@ firstapp
 │   .gitignore
 │   manifest.yml
 │   pom.xml
-├───application [firstapp-application]
-└───integration-tests [firstapp-integration-tests]
+└───application [firstapp-application]
 ```
 
-The first thing you will notice is the different directories:
+The first thing you will notice is the sub-directory `application [firstapp-application]`. This project will contain the source code of your application, as well as the tests and the configuration. The separation between the parent directory and the sub-directory allows you to add further modules as a multi-module project while defining shared dependencies centrally in the parent `pom.xml`.
 
-  - `application [firstapp-application]`
-  - `integration-tests [firstapp-integration-tests]`
-
-There are two Maven sub-modules `application [firstapp-application]` and `integration-tests [firstapp-integration-tests]`, which serve different aspects of your code application, test and deployment environment. The following separation of modules makes it possible to run dedicated unit tests and sensitive integration tests without deploying the application.
 Additionally, **`manifest.yml`** is the deployment descriptor for `Cloud Foundry`. This file will be covered in more detail later in this tutorial.
 
 #### Multiple modules project
@@ -147,39 +142,24 @@ application [firstapp-application]
     │
     └───test
         └───java
-            └───com.sap.cloud.sdk.tutorial
-                    UnitTest.java
+        │   └───com.sap.cloud.sdk.tutorial
+        │           UnitTest.java
+        │           HelloWorldControllerTest.java
+        └───resources
+                expected.json   
 ```
 
   - **`pom.xml`** - This is your project management file for Maven where you can maintain other open source dependencies or use plugins that simplify your build environment.
   - **`src/main/java`** - Here goes your production code, nothing else. As you can see, there's already the `HelloWorldController`, which will be look at in more detail soon.
   - **`src/main/resources`** - Anything that you require in your production code but is not compilable code goes here (typically things like API definition files for `OData`, `OpenAPI` or `Logback`).
-  - **`src/test/java`** - Contains the unit tests for your application. The purpose of classes in here is to test and validate single aspects of data flow and computational operations of your application project.
-
-**`integration-tests`** contains the integration tests for your application. Its structure is similar to **`application`**.
-
-```
-integration-tests [firstapp-integration-tests]
-│   pom.xml
-│
-└───src
-    └───test
-        ├───java
-        │   └───com.sap.cloud.sdk.tutorial
-        │           HelloWorldControllerTest.java
-        │
-        └───resources
-                expected.json   
-```
-
-  - **`src/test/java`**	- Here you can put all your integration tests. As you can see, it already contains `HelloWorldControllerTest` corresponding to the `HelloWorldController`.
-  - **`src/test/resources`** - Here are all the resources needed for the integration tests to run or validate.
+  - **`src/test/java`** - Contains the tests for your application. The purpose of classes in here is to test and validate the data flow and computational operations of your application project.
+  - **`src/test/resources`** - Here are all the resources needed for the tests to run or validate.
 
 #### Unit tests and integration tests
 
 This separation of test modules makes it possible to just run unit tests and integrations test without deploying, as well as deploying the application without running time consuming tests. Unit tests can either be kept publicly inside the application module `application/src/test`, or in a separate `unit-tests` module that is not part of the archetype. For that topic you can also refer to the articles and educational videos by Martin Fowler. His post about [Unit Tests](https://martinfowler.com/bliki/UnitTest.html) is a good starting point.
 
-During development it becomes important to test the code newly implemented to external services, i.e. logic running in a distributed environment. This is where the integration tests are an important tool to ensure correctness and stability over the whole internal and external deployment. Since the integration tests may contain confidential information, like business logic and test access tokens, it can be helpful to maintain their operation inside a dedicated Maven sub-module. That way the runnable application itself can be later shipped without tests and their dependency.
+During development it becomes important to test the code newly implemented to external services, i.e. logic running in a distributed environment. This is where the integration tests are an important tool to ensure correctness and stability over the whole internal and external deployment.
 
 
 ### HelloWorldController

--- a/tutorials/s4sdk-odata-service-cloud-foundry/s4sdk-odata-service-cloud-foundry.md
+++ b/tutorials/s4sdk-odata-service-cloud-foundry/s4sdk-odata-service-cloud-foundry.md
@@ -472,9 +472,9 @@ To construct an extensible integration test for the newly created `BusinessPartn
 - New: test class
 
 
-First, let's adjust the Maven pom file of the `integrations-tests` sub-module by adding a dependency for Wiremock:
+First, let's adjust the Maven pom file of the `application` sub-module by adding a dependency for Wiremock:
 
-`./integration-tests/pom.xml`
+`./application/pom.xml`
 
 ```XML
 <dependency>
@@ -491,9 +491,9 @@ _Hint: Do not forget to reload your maven project in order to include the newly 
 ### Test class
 
 
-Navigate to the integration-tests project and create a new class:
+Navigate to the application project and create a new class:
 
-`./integration-tests/src/test/java/com/sap/cloud/sdk/tutorial/BusinessPartnerControllerTest.java`
+`./application/src/test/java/com/sap/cloud/sdk/tutorial/BusinessPartnerControllerTest.java`
 
 ```Java
 package com.sap.cloud.sdk.tutorial;
@@ -613,7 +613,7 @@ In case you are trying to connect to an OData service endpoint on a server witho
 
 If you are still facing problems when connecting to the OData service, try the following to get more insights into what is happening and what can be logged:
 
-- Add a logger implementation to the test artifact's dependencies in order to get more detailed log output during tests: expand the dependencies section of `integration-tests/pom.xml` with:
+- Add a logger implementation to the test artifact's dependencies in order to get more detailed log output during tests: expand the dependencies section of `application/pom.xml` with:
 
 
 ```XML

--- a/tutorials/s4sdk-resilience/s4sdk-resilience.md
+++ b/tutorials/s4sdk-resilience/s4sdk-resilience.md
@@ -227,7 +227,7 @@ Thanks to your new `GetBusinessPartnersCommand`, you can now simply create a new
 
 Let's now write an integration test to check, if your fallback is working correctly. Add `testWithFallback()` to your `BusinessPartnerControllerTest` class:
 
- `integration-tests/src/test/java/com/sap/cloud/sdk/tutorial/BusinessPartnerControllerTest.java`:
+ `application/src/test/java/com/sap/cloud/sdk/tutorial/BusinessPartnerControllerTest.java`:
 
 ```Java
 package com.sap.cloud.sdk.tutorial;

--- a/tutorials/s4sdk-secure-cloudfoundry/s4sdk-secure-cloudfoundry.md
+++ b/tutorials/s4sdk-secure-cloudfoundry/s4sdk-secure-cloudfoundry.md
@@ -323,7 +323,7 @@ In addition all JWTs are required to contain the `Display` scope.
 Depending on your setup your integration tests may now fail if they are not authenticated.
 In that case leverage the XSUAA testing library to mock request authentication.
 
-1. Add the testing capabilities via the following dependency into your integration test `integration-tests/pom.xml`:
+1. Add the testing capabilities via the following dependency into your `application/pom.xml`:
 
     ```XML
     <dependency>
@@ -342,7 +342,7 @@ In that case leverage the XSUAA testing library to mock request authentication.
                 "sap.security.services.xsuaa.clientid=sb-clientId!t0815" } )
 ```
 
-3. Create a JWT for testing (This code snippet would be commented your test class `HelloWorldControllerTest`, just uncomment them):
+1. Create a JWT for testing (This code snippet would be commented your test class `HelloWorldControllerTest`, just uncomment them):
 
   ```JAVA
 @RegisterExtension


### PR DESCRIPTION
This PR updates all mentionings of `integration-tests` in the tutorials of the SAP Cloud SDK.

This is necessary, as the latest archetype no longer contains the named module, and migrated the contained classes over to the `application` module.