### PR TITLE
docs: fix misaligned shell commands

### DIFF
--- a/tutorials/btp-terraform-get-started/btp-terraform-get-started.md
+++ b/tutorials/btp-terraform-get-started/btp-terraform-get-started.md
@@ -65,19 +65,19 @@ Last but not least, you need to pass credentials to the provider to authenticate
 
 For Windows you have two options to export the environment variables:
 
-1. For Windows CMD use:
+If you use Windows CMD, do the export via the following commands:
 
-   ```Shell
-   set BTP_USERNAME=<your_username>
-   set BTP_PASSWORD=<your_password>
-   ```
+```Shell
+set BTP_USERNAME=<your_username>
+set BTP_PASSWORD=<your_password>
+```
 
-1. For Powershell use:
+If you use Powershell, do the export via the following commands:
 
-   ```Shell
-   $Env:BTP_USERNAME = '<your_username>'
-   $Env:BTP_PASSWORD = '<your_password>'
-   ```
+```Shell
+$Env:BTP_USERNAME = '<your_username>'
+$Env:BTP_PASSWORD = '<your_password>'
+```
 
 [OPTION END]
 


### PR DESCRIPTION
This PR contains a fix for a misalignment of the Shell commands for Windows OS due to the combination of shell tags and the enumeration.