### PR TITLE
Update btp-cockpit-setup.md to fix broken link to Free trial account …

### DIFF
--- a/tutorials/btp-cockpit-setup/btp-cockpit-setup.md
+++ b/tutorials/btp-cockpit-setup/btp-cockpit-setup.md
@@ -65,7 +65,7 @@ Choose one of the following missions:
     - [Manage Entitlements Using the Cockpit](btp-cockpit-entitlements)
     - [Create a Service Instance for SAP BTP](btp-cockpit-instances)
 
-- **Trial:** If you do not have an account of any type yet and you want to try out services for a limited amount of time, follow the instructions in [Get a Free Account on SAP BTP Trial](hcp-create-trial-account).
+- **Trial:** If you do not have an account of any type yet and you want to try out services for a limited amount of time, follow the instructions in [Get a Free Account on SAP BTP Trial](../hcp-create-trial-account/hcp-create-trial-account.md).
 
 
 


### PR DESCRIPTION
The link point to create a free tier account in BTP was broken. It should point to https://github.com/sap-tutorials/Tutorials/blob/master/tutorials/hcp-create-trial-account/hcp-create-trial-account.md