### PR TITLE
country_code instead of COUNTRY_CODE

### DIFF
--- a/tutorials/hana-cloud-cap-add-authentication/hana-cloud-cap-add-authentication.md
+++ b/tutorials/hana-cloud-cap-add-authentication/hana-cloud-cap-add-authentication.md
@@ -58,7 +58,7 @@ The UAA will provide user identity, as well as assigned roles and user attribute
     entity Languages           as projection on sap.common.Languages;
 
     @readonly
-    @restrict: [{ grant: 'READ', where: 'COUNTRY_CODE = ''DE'''}]
+    @restrict: [{ grant: 'READ', where: 'country_code = ''DE'''}]
     entity HeaderView as projection on interactions.Headers;
 
     }


### PR DESCRIPTION
QA changes in this commit: https://github.com/sap-tutorials/Tutorials-Contribution/commit/a8337288cb48eceeb995ec360e8e2624a55408d2  

Throws an error with COUNTRY_CODE, found **country_code** as the right one from the metadata
![image](https://github.com/user-attachments/assets/dd5bc82a-ba65-4994-b713-4761d7dfa1e8)
