### PR TITLE
docs: update Terraform provider version

### DIFF
--- a/tutorials/btp-terraform-get-started/btp-terraform-get-started.md
+++ b/tutorials/btp-terraform-get-started/btp-terraform-get-started.md
@@ -39,7 +39,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~>1.20.1"
+      version = "~>1.21.3"
     }
   }
 }


### PR DESCRIPTION
Update the Terraform proivder version to the latest version to stay compatible with changes on the SAP BTP APis