### PR TITLE
docs: update Terraform provider for SAP BTP version to latest

### DIFF
--- a/tutorials/btp-terraform-get-started/btp-terraform-get-started.md
+++ b/tutorials/btp-terraform-get-started/btp-terraform-get-started.md
@@ -39,7 +39,7 @@ terraform {
   required_providers {
     btp = {
       source  = "SAP/btp"
-      version = "~>1.21.3"
+      version = "~>1.22.0"
     }
   }
 }


### PR DESCRIPTION
Update Terraform provider version for "Terraform Getting Started" to latest