### PR TITLE
fix: outdent indented numbered-list items (4 tutorials)

### DIFF
--- a/tutorials/ai-core-orchestration-consumption-opt-v2/ai-core-orchestration-consumption-opt-v2.md
+++ b/tutorials/ai-core-orchestration-consumption-opt-v2/ai-core-orchestration-consumption-opt-v2.md
@@ -490,9 +490,9 @@ To test translation in Bruno:
           }
   }
 ```
-  3. Click Send.
+3. Click Send.
 
-  4. The response will show the model output in the target language, with the input also translated before being passed to the LLM.
+4. The response will show the model output in the target language, with the input also translated before being passed to the LLM.
 
 ![img](img/translation.png)
 

--- a/tutorials/ai-core-orchestration-consumption-opt/ai-core-orchestration-consumption-opt.md
+++ b/tutorials/ai-core-orchestration-consumption-opt/ai-core-orchestration-consumption-opt.md
@@ -598,9 +598,9 @@ To test translation in Bruno:
 }
 
 ```
-  3. Click Send.
+3. Click Send.
 
-  4. The response will show the model output in the target language, with the input also translated before being passed to the LLM.
+4. The response will show the model output in the target language, with the input also translated before being passed to the LLM.
 [OPTION END]
 
 ### Defining Content Filtering Rules

--- a/tutorials/hana-cloud-automation-terraform/hana-cloud-automation-terraform.md
+++ b/tutorials/hana-cloud-automation-terraform/hana-cloud-automation-terraform.md
@@ -142,7 +142,7 @@ For additional details, see [Creating SAP HANA Cloud Instances Using Terraform](
 
     ![Provision a subaccount](provision-subaccount.png)
 
-  4.  In the SAP BTP Cockpit, examine the subaccount and added entitlements.
+4. In the SAP BTP Cockpit, examine the subaccount and added entitlements.
 
     ![View the subaccount](subaccount-created.png)
 

--- a/tutorials/sapui5-101-improve-user-experience/sapui5-101-improve-user-experience.md
+++ b/tutorials/sapui5-101-improve-user-experience/sapui5-101-improve-user-experience.md
@@ -153,7 +153,7 @@ Similarly to the previous step, this step will add additional controls to the ex
 	</mvc:View>
 	```
 
-	2.	The previous snippet contains a button. Let's implement the logic to display a [MessageBox](https://sapui5.hana.ondemand.com/#/api/sap.m.MessageBox) once this button has been pressed. **Add** a missing imports and the listener for the press event in the `webapp/controller/Detail.controller.js`.
+2.	The previous snippet contains a button. Let's implement the logic to display a [MessageBox](https://sapui5.hana.ondemand.com/#/api/sap.m.MessageBox) once this button has been pressed. **Add** a missing imports and the listener for the press event in the `webapp/controller/Detail.controller.js`.
 
 		```JavaScript[2,3,4,6,34-51]
 		sap.ui.define([


### PR DESCRIPTION
## Summary

Outdents 4 numbered-list items so they sit flush with their sibling `1.` instead of being interpreted by CommonMark as nested `<ol start="N">` items. Detected by [`tutorials-ims/scripts/lint-tutorial-markdown.ts`](https://github.com/sap-tutorials/tutorials-ims/blob/main/scripts/lint-tutorial-markdown.ts) and tracked in [tutorials-ims#193](https://github.com/sap-tutorials/tutorials-ims/issues/193).

## Background

[tutorials-ims#168](https://github.com/sap-tutorials/tutorials-ims/issues/168) reported that a tutorial whose source markdown indented `2.` four spaces under `1.` rendered as a layout glitch. CommonMark parses such markup as a *separate* nested ordered list starting at 2 instead of a continuation of the original list.

The new tutorial platform surfaces this malformed DOM more visibly than legacy AEM did. The platform-side hardening already shipped in [tutorials-ims#190](https://github.com/sap-tutorials/tutorials-ims/pull/190) (so the rendering doesn't break across the catalog), and an author-side detector shipped in [tutorials-ims#191](https://github.com/sap-tutorials/tutorials-ims/pull/191).

This PR cleans up the source markdown so the underlying author input is correct (not just visually tolerated by the platform).

## Changes (4 tutorials in this repo)

| Tutorial | Lines | Fix |
|---|---|---|
| `ai-core-orchestration-consumption-opt` | L601, L603 | Outdent `3.` and `4.` from 2-space indent to flush-left |
| `ai-core-orchestration-consumption-opt-v2` | L493, L495 | Outdent `3.` and `4.` from 2-space indent to flush-left |
| `hana-cloud-automation-terraform` | L145 | Outdent `4.` from 2-space indent to flush-left + normalize post-period spacing to match siblings |
| `sapui5-101-improve-user-experience` | L156 | Remove leading tab from `2.` to match sibling `1.` (file uses tab indent) |

Per-edit verification: each numbered marker is now flush with its `1.` (or matching) sibling. CommonMark continuation content (code blocks, images) within each item retains its existing indent so it remains attached to the right list item.

## Verification

The fix can be confirmed by running [`lint-tutorial-markdown`](https://github.com/sap-tutorials/tutorials-ims/blob/main/scripts/lint-tutorial-markdown.ts) against a fresh `.tutorial-cache/` after merge — these 4 tutorials should drop off the report.

## How it was rendered before vs after

**Before** (CommonMark interpretation):
```
1. First step
2. Second step
   [code block]
   3. Click Send.       ← Renders as a NEW <ol start="3">
   4. Verify response   ← Same nested list
```

**After**:
```
1. First step
2. Second step
   [code block]
3. Click Send.            ← Continuation of the same list
4. Verify response        ← Same list
```

## Related

- Platform-side fix: [tutorials-ims#190](https://github.com/sap-tutorials/tutorials-ims/pull/190) (merged)
- Author-side lint: [tutorials-ims#191](https://github.com/sap-tutorials/tutorials-ims/pull/191) (merged)
- Original report: [tutorials-ims#168](https://github.com/sap-tutorials/tutorials-ims/issues/168) (closed)
- Tracking: [tutorials-ims#193](https://github.com/sap-tutorials/tutorials-ims/issues/193)
