### PR TITLE
fix(ci): trigger notify-tutorials-ims on master (auto-publish to PROD was dead)

### DIFF
--- a/.github/workflows/notify-tutorials-ims.yml
+++ b/.github/workflows/notify-tutorials-ims.yml
@@ -27,7 +27,7 @@ name: Notify Tutorials Platform
 
 on:
   push:
-    branches: [main]
+    branches: [master, main]
     paths:
       - '**.md'
       - '**.png'


### PR DESCRIPTION
## Problem

The content-drift check on `tutorials-ims` fails intermittently, reporting PROD slugs whose HTML in HANA no longer matches current source markdown (most recently 9 `cp-aibus-dox-*` tutorials).

**Root cause:** the automatic source→PROD publish pipeline has never fired. The intended flow is: author merges a tutorial edit here → this `notify-tutorials-ims.yml` sends a `repository_dispatch: tutorial-updated` → `tutorials-ims`'s `rebuild-content.yml` republishes PROD.

But this repo's default branch is **`master`**, while the workflow triggered only on `push: branches: [main]` — a branch that does not exist. So the workflow has **never run** (zero historical runs), no dispatch ever reached `tutorials-ims`, and PROD is only ever refreshed by a manual `workflow_dispatch`. Drift appears whenever content is edited on `master` and no one manually rebuilds.

## Fix

Trigger on `[master, main]` — fires today on the real default branch, and survives a future rename to `main`.

```diff
   push:
-    branches: [main]
+    branches: [master, main]
```

## Follow-up (not in this PR)

Verify this repo has the dispatch credentials configured, or the dispatch will 401 silently once it starts firing:
- either `USE_GITHUB_APP=true` + Actions secrets `TUTORIALS_APP_ID` / `TUTORIALS_APP_PRIVATE_KEY` (App installed with Contents:write on `tutorials-ims`), or
- the legacy `TUTORIALS_DISPATCH_TOKEN` PAT (repo scope on `tutorials-ims`).

The immediate drift was healed separately via a manual `rebuild-content.yml -f environment=prod`.
