### PR TITLE
feat: use video: frontmatter for hana-cloud-cap-create-ui intro video

### DIFF
--- a/tutorials/hana-cloud-cap-create-ui/hana-cloud-cap-create-ui.md
+++ b/tutorials/hana-cloud-cap-create-ui/hana-cloud-cap-create-ui.md
@@ -5,6 +5,9 @@ author_profile: https://github.com/jung-thomas
 tags: [ tutorial>beginner, products>sap-hana, products>sap-business-application-studio, software-product-function>sap-cloud-application-programming-model]
 primary_tag: products>sap-hana-cloud
 parser: v2
+video:
+  url: https://www.youtube.com/watch?v=6WY70LyLS1c
+  title: Create a User Interface with CAP (SAP HANA Cloud)
 ---
 
 # Create a User Interface with CAP (SAP HANA Cloud)
@@ -20,12 +23,6 @@ parser: v2
 
 - This tutorial is designed for SAP HANA Cloud. It is not designed for SAP HANA on premise or SAP HANA, express edition.
 - You have created database artifacts and loaded data as explained in [the previous tutorial](hana-cloud-cap-create-database-cds).
-
-## Video Version
-
-Video tutorial version:
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/6WY70LyLS1c" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ### Run the services
 


### PR DESCRIPTION
Converts the intro video for **hana-cloud-cap-create-ui** from the legacy raw-`<iframe>` `## Video Version` section to the new `video:` frontmatter supported by the tutorial platform (tutorials-ims #1477).

**Change:**
- Add to frontmatter:
  ```yaml
  video:
    url: https://www.youtube.com/watch?v=6WY70LyLS1c
    title: Create a User Interface with CAP (SAP HANA Cloud)
  ```
- Remove the `## Video Version` section (heading + intro line + raw `<iframe>`).

**Why:** The platform now renders `video:` frontmatter as a styled, responsive 16:9 player at the top of the Steps section. The raw-iframe approach still works (also supported), but frontmatter is the cleaner authoring path. This is the reference/first migration of the 20 tutorials that carried a pre-step video.

Same edit is being applied to `Tutorials-Contribution` to keep the two source repos in sync.
