### PR TITLE
fix(hana-cloud-automation-cli): move intro prose+images out of 'You will learn'

### DIFF
--- a/tutorials/hana-cloud-automation-cli/hana-cloud-automation-cli.md
+++ b/tutorials/hana-cloud-automation-cli/hana-cloud-automation-cli.md
@@ -21,6 +21,8 @@ primary_tag: software-product>sap-hana-cloud
   - An overview of two different runtimes that SAP HANA Cloud can be provisioned into
   - How to use the BTP, CF, and service manager command line interfaces (CLIs) with an SAP HANA Cloud instance
 
+## Overview
+
 SAP HANA Cloud Central can be used to perform many administrative tasks for SAP HANA Cloud instances within a graphical interface such as creating, deleting, starting, stopping, updating, upgrading, cloning, or running diagnostic checks. 
 
 ![SAP HANA Cloud Central](HCC.png)


### PR DESCRIPTION
## Problem
On [the published tutorial](https://developers.sap.com/tutorials/hana-cloud-automation-cli), the two images in the **You will learn** section (`HCC.png`, `running-scheduling.png`) are broken links, and the overview prose renders awkwardly inside the check-list.

## Cause
The `## You will learn` section contains its 3 bullets **plus** two paragraphs of overview prose and two figures. That section is a bullet-list-only region; the platform folds the trailing prose/images into the last bullet, where images keep a bare relative `src` and 404.

## Fix
Add an `## Overview` heading before the overview prose. The three learning-objective bullets stay under **You will learn**; the overview text + both figures now render as the tutorial's intro (above Step 1) with correct image handling. No step content changed.

Verified with the platform parser: `youWillLearn` → 3 clean bullets, intro carries both images with resolvable URLs, all 7 steps intact.

_Note: a companion platform-side fix (sap-tutorials/tutorials-ims#1856) also hardens the parser so stray images in that section no longer 404 for any tutorial._