### PR TITLE
fix(hana-dbx-multi-model): remove duplicated author frontmatter keys

### DIFF
--- a/tutorials/hana-dbx-multi-model/hana-dbx-multi-model.md
+++ b/tutorials/hana-dbx-multi-model/hana-dbx-multi-model.md
@@ -2,8 +2,6 @@
 parser: v2
 author_name: Dan van Leeuwen
 author_profile: https://github.com/danielva
-author_name: Dan van Leeuwen
-author_profile: https://github.com/danielva
 auto_validation: true
 time: 15
 tags: [ tutorial>beginner, software-product-function>sap-hana-cloud--sap-hana-database, software-product>sap-hana, software-product>sap-hana--express-edition, software-product-function>sap-hana-multi-model-processing, software-product-function>sap-hana-spatial, software-product-function>sap-hana-graph, tutorial>license]


### PR DESCRIPTION
## What
Remove the duplicated `author_name` / `author_profile` keys from the YAML frontmatter of `hana-dbx-multi-model.md`.

## Why
Commit 631e60d4 ("Updates to SAP HANA Cloud tutorials", 2026-08-16) added the author attribution lines **twice**:

```yaml
---
parser: v2
author_name: Dan van Leeuwen
author_profile: https://github.com/danielva
author_name: Dan van Leeuwen        # <-- duplicate
author_profile: https://github.com/danielva   # <-- duplicate
auto_validation: true
```

This is invalid YAML (`duplicated mapping key at line 5, column 1`). Consequences on the developers.sap.com tutorials platform:

- The tutorial **fails frontmatter parsing** and cannot be rebuilt/republished.
- It shows as **content drift** — the prod nightly drift check failed on 2026-08-17 with exactly this one slug ([run 31994470191](https://github.com/sap-tutorials/tutorials-ims/actions/runs/31994470191)). Prod is still serving the previous valid version, so there is no visitor-facing outage.

## Fix
Delete the two duplicate lines (5–6), keeping the first `author_name`/`author_profile` pair. Byte-verified: only those two lines removed, CRLF endings preserved, and the frontmatter now parses with no duplicate keys.

After merge, the next content rebuild republishes the tutorial and clears the drift signal.