### PR TITLE
Refresh cp-prepare-local-dev: fix broken installers, rebrand tag, pin Node LTS

### DIFF
--- a/tutorials/cp-prepare-local-dev/cp-prepare-local-dev.md
+++ b/tutorials/cp-prepare-local-dev/cp-prepare-local-dev.md
@@ -3,8 +3,8 @@ parser: v2
 auto_validation: true
 author_name: Thomas Jung
 author_profile: https://github.com/jung-thomas
-primary_tag: products>sap-cloud-platform
-tags: [ products>sap-cloud-platform, topic>cloud, tutorial>beginner, programming-tool>node-js ]
+primary_tag: products>sap-business-technology-platform
+tags: [ products>sap-business-technology-platform, topic>cloud, tutorial>beginner, programming-tool>node-js ]
 time: 20
 ---
 
@@ -33,16 +33,16 @@ We recommend using a package manager on your OS.
 
 [OPTION BEGIN [Windows]]
 
-**Install** the Windows package manager [Chocolatey](https://chocolatey.org/).
+**Install** the Windows package manager [Chocolatey](https://chocolatey.org/) by running the following in an **administrative** PowerShell:
 
 ```Terminal
-@powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 ```
 
-**Install Node.js**
+**Install Node.js** (the current Long-Term Support release)
 
 ```Terminal
-choco install nodejs
+choco install nodejs-lts
 ```
 
 
@@ -53,13 +53,13 @@ choco install nodejs
 **Install** the Mac package manager [Homebrew](https://brew.sh/).
 
 ```Terminal
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
 **Install Node.js**
 
 ```Terminal
-brew install nodejs
+brew install node
 ```
 
 
@@ -80,6 +80,8 @@ To verify if the installation was successful, check the `npm` and `node.js` vers
 node -v
 npm -v
 ```
+
+> This tutorial requires **Node.js 20 LTS or later**. If `node -v` reports an older version, install a current Long-Term Support release before continuing.
 
 ### Install the cloud MTA build tool
 

--- a/tutorials/cp-prepare-local-dev/cp-prepare-local-dev.md
+++ b/tutorials/cp-prepare-local-dev/cp-prepare-local-dev.md
@@ -64,9 +64,9 @@ brew install node
 
 
 [OPTION END]
-[OPTION BEGIN [Other]]
+[OPTION BEGIN [Linux]]
 
-**Install** the Node.js from the  [official website](https://nodejs.org/en/download/).
+**Install Node.js** via your distribution's package manager, or download the current LTS build from the [official website](https://nodejs.org/en/download).
 
 [OPTION END]
 
@@ -102,10 +102,12 @@ npm install -g mbt
 [OPTION END]
 [OPTION BEGIN [Mac]]
 
-[OPTION END]
-[OPTION BEGIN [Other]]
+> This tool depends on [GNU make](https://www.gnu.org/software/make/). On macOS it is provided by the Xcode Command Line Tools — run `xcode-select --install` if it is not already installed.
 
-> This tool depends on [GNU make](https://www.gnu.org/software/make/) that is most likely already installed when you use a Unix-based OS. In case this tool is not installed on your machine, install it from [here](http://ftp.gnu.org/gnu/make/).
+[OPTION END]
+[OPTION BEGIN [Linux]]
+
+> This tool depends on [GNU make](https://www.gnu.org/software/make/), which is most likely already installed on a Unix-based OS. If it is missing, install it with your distribution's package manager (for example, `sudo apt install make`).
 
 
 [OPTION END]
@@ -132,9 +134,9 @@ brew install git
 
 
 [OPTION END]
-[OPTION BEGIN [Other]]
+[OPTION BEGIN [Linux]]
 
-**Install** the git from the  [official website](https://git-scm.com/downloads).
+**Install** git with your distribution's package manager (for example, `sudo apt install git`), or download it from the [official website](https://git-scm.com/downloads).
 
 
 [OPTION END]


### PR DESCRIPTION
## Refresh `cp-prepare-local-dev` (Prepare the Local Development Environment)

Content review of this beginner setup tutorial. Fixes verified against the current source; scoped to high-confidence correctness and discoverability issues.

### Changes
- **Fix broken Homebrew installer** — the old `ruby -e ".../install/master/install"` command was retired by Homebrew (~2019, `master` branch renamed) and **fails today**. Replaced with the current `bash .../install/HEAD/install.sh`.
- **Modernize Chocolatey install** — updated to the official `community.chocolatey.org/install.ps1` invocation with the TLS 1.2 bootstrap, run in an administrative PowerShell.
- **Pin Node.js to LTS** — `choco install nodejs` → `choco install nodejs-lts`; added a "Node.js 20 LTS or later" minimum-version note in the Verify step (previously no version was stated, so learners could land on a non-LTS/outdated build).
- **Fix Homebrew formula name** — `brew install nodejs` → `brew install node`.
- **Rebrand primary tag** — `products>sap-cloud-platform` → `products>sap-business-technology-platform` (SAP BTP), restoring search visibility.

### Deliberately *not* changed (Joule flagged these, but they're already present)
- Verify step exists (`node -v` / `npm -v`); tutorial already has `auto_validation: true`.
- Already split one-step-per-tool (Node.js → Verify → MTA → git).
- Already branches per OS via `[OPTION [Windows]]/[Mac]/[Other]`.
- **No screenshots** are referenced and none exist in the folder — nothing to update.

### Follow-up (needs data, not in this PR)
Joule reports zero completions against 2020–2021 starts. Since `auto_validation` is on and a verify step exists, this reads as possibly an **analytics completion-fact/task-ID artifact** as much as a content defect — worth confirming the completion query resolves this slug's task ID before adding a validation quiz.

---

### Adopt the global OS picker
The tutorial's per-step `[OPTION]` groups used `[Windows]/[Mac]/[Other]`. `Other`
doesn't classify as an OS, so the platform rendered plain per-step tabs instead of
the single global OS picker. Relabeled `[Other]` → `[Linux]` across all three groups
(Node.js, `make` dependency, git) and filled the previously-empty macOS `make` panel
(`xcode-select --install`).

Verified against the platform parser (`convertOptionBlocks`, target `hugo`): all three
groups now classify as `os` and emit `{{< os-options >}}`/`{{< os-panel >}}` (9 panels
across Windows/macOS/Linux); no legacy `option-tabs` remain. Content is unchanged
functionally — Linux users get package-manager + official-site guidance in place of the
generic "Other" instructions.
