### PR TITLE
Rework hxe-database-server into a branched server-only deployment decision guide

### DIFF
--- a/tutorials/hxe-database-server/hxe-database-server.md
+++ b/tutorials/hxe-database-server/hxe-database-server.md
@@ -29,7 +29,7 @@ primary_tag: products>sap-hana\,-express-edition
 
 This is a short **decision guide**, not a hands-on installation walkthrough. Its goal is to help you pick the deployment method that matches your machine and skill level, then send you to the dedicated tutorial that walks through that method step by step.
 
-This tutorial covers the **server-only** package — the SAP HANA database engine on its own, without XS Advanced or other application services. If you need those application services, follow one of the full-installation guides linked below instead.
+This tutorial covers the **server-only** package — the SAP HANA database engine on its own, without XS Advanced or other application services. If you need those application services, follow one of the full-installation guides linked from the branches below instead.
 
 ---
 
@@ -40,21 +40,47 @@ Before choosing a method, confirm your laptop or server meets the minimum requir
 - **8 GB RAM minimum**, **12 GB recommended** for the server-only version.
 - Sufficient free disk space for the download and install.
 
-> ### Not enough RAM or disk space?
+> **Not enough RAM or disk space?**
 >
 > If your machine does not meet these requirements, use **SAP HANA Cloud trial** instead — a completely free, hosted, cloud-managed solution with nothing to install locally. See [Deploy SAP HANA Cloud trial](hana-cloud-deploying).
 
 ### Choose your deployment method
 
-Pick the row that matches your situation and follow the linked tutorial. You only need **one** of these methods.
+You will deploy using **one** of the methods below. Pick the branch that matches your machine and experience level — you only need to complete the one you choose, and the picker above hides the paths that don't apply to you.
 
-| If you… | Choose | Then follow |
-| --- | --- | --- |
-| Want the fastest setup on a supported Linux distribution and are comfortable with Docker | **Docker container** | [Installing SAP HANA, express edition with Docker](hxe-ua-install-using-docker) |
-| Want to customize the operating system or platform and are comfortable with Linux administration | **Binary installer** | [Install SAP HANA, express edition on a Native Linux Machine](group.hxe-install-binary) |
-| Are on Windows or macOS, or have limited local resources | **SAP HANA Cloud trial** (no local install) | [Deploy SAP HANA Cloud trial](hana-cloud-deploying) |
+[BRANCH_BEGIN group="deployment" key="docker" label="Docker container"]
 
-> The **Docker** and **binary installer** options run on Linux operating systems only. On Windows or macOS, run them inside a Linux virtual machine, or use SAP HANA Cloud trial instead.
+### Deploy with Docker (Linux only)
+
+Best if you want the fastest setup on a supported Linux distribution and are comfortable with Docker.
+
+Follow the step-by-step guide: [Installing SAP HANA, express edition with Docker](hxe-ua-install-using-docker).
+
+> Runs on Linux operating systems only. On Windows or macOS, run it inside a Linux virtual machine, or choose the **SAP HANA Cloud trial** branch instead.
+
+[BRANCH_END]
+
+[BRANCH_BEGIN group="deployment" key="binary" label="Binary installer"]
+
+### Deploy with the binary installer (Linux)
+
+Best if you want to customize the operating system or platform and are comfortable with Linux administration. This option allows for some customization of the operating system and the platform.
+
+Follow the step-by-step guide: [Install SAP HANA, express edition on a Native Linux Machine](group.hxe-install-binary).
+
+> Requires a minimum level of expertise with Linux operating systems and runs on Linux only.
+
+[BRANCH_END]
+
+[BRANCH_BEGIN group="deployment" key="cloud" label="SAP HANA Cloud trial" condition="profile.deployment == 'cloud'"]
+
+### Use SAP HANA Cloud trial (no local install)
+
+Best if you are on Windows or macOS, or have limited local resources. This is a completely free, hosted, cloud-managed option with nothing to install locally.
+
+Follow the step-by-step guide: [Deploy SAP HANA Cloud trial](hana-cloud-deploying).
+
+[BRANCH_END]
 
 ### What's next
 

--- a/tutorials/hxe-database-server/hxe-database-server.md
+++ b/tutorials/hxe-database-server/hxe-database-server.md
@@ -7,44 +7,61 @@ tags: [ tutorial>beginner, products>sap-hana\,-express-edition]
 primary_tag: products>sap-hana\,-express-edition
 ---
 
-# SAP HANA, express edition - Server Only Deployment Options
+# SAP HANA, express edition - Choose a Server-Only Deployment Method
 
-<!-- description --> Learn the options to deploy the database-only version of SAP HANA, express edition in a local computer.
+<!-- description --> A decision guide to help you pick the right way to deploy the database-only (server-only) version of SAP HANA, express edition on your local computer, then point you to the hands-on installation tutorial that matches your setup.
 
 ## Prerequisites
 
-- You must register for the product before downloading SAP HANA, express edition. Follow the steps in [Register for SAP HANA, express edition](hxe-ua-register).
+- **Registration:** You must register for the product before downloading SAP HANA, express edition. Follow the steps in [Register for SAP HANA, express edition](hxe-ua-register).
+- **Memory:** 8 GB RAM minimum; 12 GB recommended for the server-only version.
+- **Disk space:** Sufficient free disk space for the download and installation — see your chosen installation guide for the exact figure.
+- **Operating system:** A supported 64-bit Linux distribution. The server-only version does not install natively on Windows or macOS — on those hosts use Docker, a Linux virtual machine, or SAP HANA Cloud trial.
+- **Docker (Docker path only):** A working Docker installation on a supported Linux distribution.
 
-## You will learn  
+## You will learn
 
-- How to deploy locally the database-only version of SAP HANA, express edition
+- How to compare the local deployment methods for the server-only (database) version of SAP HANA, express edition
+- How to choose the method that fits your operating system and experience level
+- Where to go next once your instance is running
 
 ## Intro
 
-Choose one of the steps below for a local deployment of SAP HANA, express edition.
+This is a short **decision guide**, not a hands-on installation walkthrough. Its goal is to help you pick the deployment method that matches your machine and skill level, then send you to the dedicated tutorial that walks through that method step by step.
+
+This tutorial covers the **server-only** package — the SAP HANA database engine on its own, without XS Advanced or other application services. If you need those application services, follow one of the full-installation guides linked below instead.
 
 ---
 
-### Check RAM memory in your laptop
+### Confirm your machine has enough memory
 
->To deploy locally, you must have 8GB RAM, but 12GB is recommended.
+Before choosing a method, confirm your laptop or server meets the minimum requirements for a local deployment:
 
-> ###  Not enough RAM or space on disk?
+- **8 GB RAM minimum**, **12 GB recommended** for the server-only version.
+- Sufficient free disk space for the download and install.
 
-If you do not have enough RAM, we would recommend SAP HANA Cloud trial which is a completely free, hosted and cloud managed solution. [Deploy SAP HANA Cloud trial](hana-cloud-deploying)
+> ### Not enough RAM or disk space?
+>
+> If your machine does not meet these requirements, use **SAP HANA Cloud trial** instead — a completely free, hosted, cloud-managed solution with nothing to install locally. See [Deploy SAP HANA Cloud trial](hana-cloud-deploying).
 
-### Docker container on a Linux operating system
+### Choose your deployment method
 
-***This option runs on Linux operating systems only.***
+Pick the row that matches your situation and follow the linked tutorial. You only need **one** of these methods.
 
-Follow these instructions to pull and run the Docker container in any of the supported Linux distributions: [Installing SAP HANA, express edition with Docker](hxe-ua-install-using-docker)
+| If you… | Choose | Then follow |
+| --- | --- | --- |
+| Want the fastest setup on a supported Linux distribution and are comfortable with Docker | **Docker container** | [Installing SAP HANA, express edition with Docker](hxe-ua-install-using-docker) |
+| Want to customize the operating system or platform and are comfortable with Linux administration | **Binary installer** | [Install SAP HANA, express edition on a Native Linux Machine](group.hxe-install-binary) |
+| Are on Windows or macOS, or have limited local resources | **SAP HANA Cloud trial** (no local install) | [Deploy SAP HANA Cloud trial](hana-cloud-deploying) |
 
-### Manual installation using Binary Installer
+> The **Docker** and **binary installer** options run on Linux operating systems only. On Windows or macOS, run them inside a Linux virtual machine, or use SAP HANA Cloud trial instead.
 
-***This option requires a minimum level of expertise with Linux operating systems.***
+### What's next
 
-This option allows for some customization of the operating system and the platform.
+Once your server-only instance is running, continue with:
 
-See [Install SAP HANA, express edition on a Native Linux Machine](group.hxe-install-binary).
+- [Get Started with the SAP HANA Database Explorer](hana-dbx-overview) — connect to your new instance, set your passwords, and run your first SQL.
+- [Register for SAP HANA, express edition](hxe-ua-register) — if you have not registered yet.
+- Explore more SAP HANA learning content on [SAP Learning](https://learning.sap.com) to deepen your database administration and development skills.
 
 ---


### PR DESCRIPTION
Reworks the `hxe-database-server` tutorial to address a severe completion gap (23 starts / <5 completions over 180 days).

**What changed**
- Uses the platform's **native branch picker** (`[BRANCH_BEGIN]`/`[BRANCH_END]`, per [branched-tutorials](https://github.com/sap-tutorials/tutorials-ims/blob/main/docs/authors/branched-tutorials.md)) for the deployment fork — Docker / binary installer / SAP HANA Cloud trial — so learners see only the path they pick. This is the classic deployment-fork case and the biggest completion lever.
- Reframed as an explicit **decision guide** (not a hands-on walkthrough); clarified title + description.
- Added a **Prerequisites** section (registration, memory 8 GB min / 12 GB recommended for *server-only*, disk, OS, Docker).
- Added a **"What's next"** step → `hana-dbx-overview`, `hxe-ua-register`, SAP Learning.

**Branching notes**
- Three sibling branches share `group="deployment"`; keys `docker` / `binary` / `cloud`. Each branch has one H3 sub-step that links to the dedicated install tutorial (branches can't join another tutorial's content, so they route out).
- `condition="profile.deployment == 'cloud'"` on the HANA Cloud trial branch; the others rely on the runtime ranker. No `skipIf` — there's no meaningful auto-skip here.

**Deliberately not applied:** the Server-only-vs-Server+Apps package decision tree and per-step splitting (both assume a hands-on multi-method walkthrough this router isn't). Kept **12 GB recommended** (server-only), not 16 GB (Server + Apps).

> Supersedes the table-based first pass (Contribution PR #42147, already merged) — this converts that table into the native branch picker.

---
🔗 Mirrored pair. Companion PR (Contribution repo): https://github.com/sap-tutorials/Tutorials-Contribution/pull/42149