### PR TITLE
Clarify cp-prepare-local-dev: prerequisites table, per-tool verification, Next steps

### DIFF
--- a/tutorials/cp-prepare-local-dev/cp-prepare-local-dev.md
+++ b/tutorials/cp-prepare-local-dev/cp-prepare-local-dev.md
@@ -11,15 +11,27 @@ time: 20
 
 
 # Prepare the Local Development Environment
-<!-- description --> Install essential runtimes and tools for local development.
+<!-- description --> Install Node.js, npm, git, and the Cloud MTA Build Tool (`mbt`) to build and deploy SAP BTP apps from your own machine.
 
-## You will learn  
-  - How to install Node.js and npm (Node Package Manager) as a runtime
-  - How to install essential tools like git and Cloud MTA Build Tool (`mbt`)
+## You will learn
+  - How to install the Node.js runtime and the npm (Node Package Manager) package manager
+  - How to install the Cloud MTA Build Tool (`mbt`) to package deployable `.mtar` archives
+  - How to install git to clone and version-control projects
+  - How to verify each tool from the command line
+
+## Prerequisites
+  - A machine running **Windows**, **macOS**, or **Linux**, with administrator rights to install software
+
+| Tool | Minimum version | Verify with |
+| ---- | --------------- | ----------- |
+| Node.js | 20 LTS or later | `node -v` |
+| npm | bundled with Node.js | `npm -v` |
+| Cloud MTA Build Tool (`mbt`) | latest | `mbt -v` |
+| git | latest | `git --version` |
 
 ---
 
-### Install the Node.js runtime
+### Install Node.js (20 LTS or later)
 
 >Node.js is a server-side runtime environment built on Chrome's V8 JavaScript engine. It provides an event-driven, non-blocking (asynchronous) I/O and cross-platform runtime environment. It enables you to build scalable server-side applications using JavaScript and is open-source.
 >&nbsp;
@@ -70,11 +82,7 @@ brew install node
 
 [OPTION END]
 
-
-### Verify your installation
-
-
-To verify if the installation was successful, check the `npm` and `node.js` version. Open the command line and print for the installed version.
+**Verify your installation.** Open the command line and print the installed versions of `node` and `npm`:
 
 ```Terminal
 node -v
@@ -83,7 +91,7 @@ npm -v
 
 > This tutorial requires **Node.js 20 LTS or later**. If `node -v` reports an older version, install a current Long-Term Support release before continuing.
 
-### Install the cloud MTA build tool
+### Install the Cloud MTA Build Tool (`mbt`)
 
 
 This tool will create so-called `.mtar` archives, which are deployable packages that contain your entire project. The tool itself is an OS-dependent binary, but you can leverage [npm](https://www.npmjs.com/package/mbt) to install the right version for your OS and append it to the Path variable. Run the following command to install this tool:
@@ -111,6 +119,14 @@ npm install -g mbt
 
 
 [OPTION END]
+
+**Verify your installation.** Print the installed version:
+
+```Terminal
+mbt -v
+```
+
+> You should see output similar to `Cloud MTA Build Tool version 1.2.47`.
 
 ### Install git
 
@@ -140,6 +156,19 @@ brew install git
 
 
 [OPTION END]
+
+**Verify your installation.** Print the installed version:
+
+```Terminal
+git --version
+```
+
+### Next steps
+
+
+You now have the Node.js runtime, npm, the Cloud MTA Build Tool (`mbt`), and git installed and verified — everything you need to clone a project, build it, and package a deployable `.mtar` archive locally.
+
+Continue with the SAP BTP mission or learning path that brought you here, or discover more hands-on content in the [SAP Tutorial Navigator](https://developers.sap.com/tutorial-navigator.html).
 
 
 


### PR DESCRIPTION
## What

Reworks the **Prepare the Local Development Environment** (`cp-prepare-local-dev`) tutorial for clarity and a clearer completion signal:

- Description now names the actual tools (Node.js, npm, git, `mbt`) instead of "essential runtimes and tools".
- New **Prerequisites** section with a version + how-to-verify table.
- Specific, scannable step titles (e.g. "Install Node.js (20 LTS or later)").
- A **verify command at the end of every install step**: `node -v`/`npm -v`, `mbt -v`, `git --version`.
- Added a short **Next steps** close linking to the SAP Tutorial Navigator.

All OS-specific `[OPTION]` branches, the `primary_tag`, and other prose are unchanged. `mbt -v` was confirmed as the correct version flag (`mbt version` prints usage, not a version).

_This is one half of a mirrored Contribution ↔ canonical pair._ Companion PR: https://github.com/sap-tutorials/Tutorials-Contribution/pull/42148
