### PR TITLE
fix(tags): correct malformed 'tutorial:how-to' delimiter (1 file)

### DIFF
--- a/tutorials/add-cross-origin-preview-page/add-cross-origin-preview-page.md
+++ b/tutorials/add-cross-origin-preview-page/add-cross-origin-preview-page.md
@@ -4,7 +4,7 @@ author_name: David Klug
 author_profile: https://github.com/david-klug-sap
 auto_validation: true
 time: 20
-tags: [ tutorial>advanced, tutorial:how-to, software-product>sap-business-technology-platform, software-product>ui-theme-designer]
+tags: [ tutorial>advanced, tutorial>how-to, software-product>sap-business-technology-platform, software-product>ui-theme-designer]
 primary_tag: software-product>ui-theme-designer
 ---
 


### PR DESCRIPTION
## Defect
The tutorial `add-cross-origin-preview-page` uses a malformed tag `tutorial:how-to` (colon delimiter) on its frontmatter `tags:` line. The taxonomy delimiter is `>`, so this token is not a recognized tag.

## Fix
Replace the single malformed token with the canonical slug:
- `tutorial:how-to` → `tutorial>how-to`

Only that one token on the `tags:` line is changed. No body text is touched.

## Scope
**1 file** — `tutorials/add-cross-origin-preview-page/add-cross-origin-preview-page.md`

## Context
Flagged by the new `tutorial-ci` frontmatter-unknown-tag check. This is a stale/malformed product tag cleanup. Publishing/rebuild so the change takes effect on the live site is a separate maintainer step.