### PR TITLE
fix(tags): rename stale 'sap-btp--cloud-foundry-environment' product tag (34 files)

### DIFF
--- a/tutorials/alert-notification-service/alert-notification-service.md
+++ b/tutorials/alert-notification-service/alert-notification-service.md
@@ -7,7 +7,7 @@ keywords: tutorial
 auto_validation: true
 time: 30
 tags: [ tutorial>beginner, software-product-function>sap-btp-cockpit, software-product>sap-alert-notification-service-for-sap-btp ]
-primary_tag: software-product>sap-btp--cloud-foundry-environment
+primary_tag: software-product>sap-btp--cloud-foundry-runtime-and-environment
 parser: v2
 ---
 

--- a/tutorials/appstudio-sapui5-create/appstudio-sapui5-create.md
+++ b/tutorials/appstudio-sapui5-create/appstudio-sapui5-create.md
@@ -3,7 +3,7 @@ parser: v2
 auto_validation: true
 time: 25
 tags: [ tutorial>beginner, programming-tool>javascript, programming-tool>sapui5, programming-tool>html5, software-product>sap-business-technology-platform, software-product>sap-business-application-studio]
-primary_tag: software-product>sap-btp--cloud-foundry-environment
+primary_tag: software-product>sap-btp--cloud-foundry-runtime-and-environment
 author_name: Conrad Bernal
 author_profile: https://github.com/cjbernal
 ---

--- a/tutorials/btp-cf-deploy-mta/btp-cf-deploy-mta.md
+++ b/tutorials/btp-cf-deploy-mta/btp-cf-deploy-mta.md
@@ -4,7 +4,7 @@ author_name: Lilyana Rangelova
 author_profile: https://github.com/lilyanarangelova
 auto_validation: true
 time: 30
-tags: [ tutorial>intermediate, products>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>intermediate, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: products>sap-business-technology-platform
 ---
 

--- a/tutorials/cap-extend-sfsf-add-launchpad/cap-extend-sfsf-add-launchpad.md
+++ b/tutorials/cap-extend-sfsf-add-launchpad/cap-extend-sfsf-add-launchpad.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 7
-tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: software-product-function>sap-cloud-application-programming-model
 author_name: Alessandro Biagi
 author_profile: https://github.com/ale-biagi

--- a/tutorials/cap-extend-sfsf-add-logic/cap-extend-sfsf-add-logic.md
+++ b/tutorials/cap-extend-sfsf-add-logic/cap-extend-sfsf-add-logic.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 15
-tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: software-product-function>sap-cloud-application-programming-model
 author_name: Alessandro Biagi
 author_profile: https://github.com/ale-biagi

--- a/tutorials/cap-extend-sfsf-add-security/cap-extend-sfsf-add-security.md
+++ b/tutorials/cap-extend-sfsf-add-security/cap-extend-sfsf-add-security.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 10
-tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: software-product-function>sap-cloud-application-programming-model
 ---
 

--- a/tutorials/cap-extend-sfsf-create-service/cap-extend-sfsf-create-service.md
+++ b/tutorials/cap-extend-sfsf-create-service/cap-extend-sfsf-create-service.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 6
-tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: software-product-function>sap-cloud-application-programming-model
 ---
 

--- a/tutorials/cap-extend-sfsf-data-model/cap-extend-sfsf-data-model.md
+++ b/tutorials/cap-extend-sfsf-data-model/cap-extend-sfsf-data-model.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 11
-tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: software-product-function>sap-cloud-application-programming-model
 ---
 

--- a/tutorials/cap-extend-sfsf-deploy-cf/cap-extend-sfsf-deploy-cf.md
+++ b/tutorials/cap-extend-sfsf-deploy-cf/cap-extend-sfsf-deploy-cf.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 8
-tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: software-product-function>sap-cloud-application-programming-model
 ---
 

--- a/tutorials/cap-extend-sfsf-deploy-hc/cap-extend-sfsf-deploy-hc.md
+++ b/tutorials/cap-extend-sfsf-deploy-hc/cap-extend-sfsf-deploy-hc.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 7
-tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: software-product-function>sap-cloud-application-programming-model
 author_name: Alessandro Biagi
 author_profile: https://github.com/ale-biagi

--- a/tutorials/cap-extend-sfsf-fiori-elements/cap-extend-sfsf-fiori-elements.md
+++ b/tutorials/cap-extend-sfsf-fiori-elements/cap-extend-sfsf-fiori-elements.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 15
-tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: software-product-function>sap-cloud-application-programming-model
 ---
 

--- a/tutorials/cap-extend-sfsf-import-services/cap-extend-sfsf-import-services.md
+++ b/tutorials/cap-extend-sfsf-import-services/cap-extend-sfsf-import-services.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 10
-tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: software-product-function>sap-cloud-application-programming-model
 ---
 

--- a/tutorials/cap-extend-sfsf-intro/cap-extend-sfsf-intro.md
+++ b/tutorials/cap-extend-sfsf-intro/cap-extend-sfsf-intro.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 10
-tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: software-product-function>sap-cloud-application-programming-model
 author_name: Alessandro Biagi
 author_profile: https://github.com/ale-biagi

--- a/tutorials/cap-extend-sfsf-jumpstart/cap-extend-sfsf-jumpstart.md
+++ b/tutorials/cap-extend-sfsf-jumpstart/cap-extend-sfsf-jumpstart.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 6
-tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: software-product-function>sap-cloud-application-programming-model
 author_name: Alessandro Biagi
 author_profile: https://github.com/ale-biagi

--- a/tutorials/cap-extend-sfsf-ui-annotations/cap-extend-sfsf-ui-annotations.md
+++ b/tutorials/cap-extend-sfsf-ui-annotations/cap-extend-sfsf-ui-annotations.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 15
-tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: software-product-function>sap-cloud-application-programming-model
 ---
 

--- a/tutorials/cp-cf-download-cli/cp-cf-download-cli.md
+++ b/tutorials/cp-cf-download-cli/cp-cf-download-cli.md
@@ -4,7 +4,7 @@ auto_validation: true
 author_name: Nico Schoenteich
 author_profile: https://github.com/nicoschoenteich
 tags: [tutorial>beginner, topic>cloud, products>sap-business-technology-platform ]
-primary_tag: products>sap-btp--cloud-foundry-environment
+primary_tag: software-product>sap-btp--cloud-foundry-runtime-and-environment
 time: 15
 ---
 

--- a/tutorials/cp-cf-install-cliplugin-mta/cp-cf-install-cliplugin-mta.md
+++ b/tutorials/cp-cf-install-cliplugin-mta/cp-cf-install-cliplugin-mta.md
@@ -5,7 +5,7 @@ author_name: DJ Adams
 author_profile: https://github.com/qmacro
 time: 5
 tags: [ tutorial>beginner, topic>cloud]
-primary_tag: products>sap-btp--cloud-foundry-environment
+primary_tag: software-product>sap-btp--cloud-foundry-runtime-and-environment
 
 ---
 

--- a/tutorials/cp-cf-sapui5-local-debug/cp-cf-sapui5-local-debug.md
+++ b/tutorials/cp-cf-sapui5-local-debug/cp-cf-sapui5-local-debug.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 15
-tags: [ tutorial>beginner, programming-tool>html5, topic>cloud, programming-tool>javascript, software-product>sap-btp--cloud-foundry-environment, tutorial>free-tier]
+tags: [ tutorial>beginner, programming-tool>html5, topic>cloud, programming-tool>javascript, software-product>sap-btp--cloud-foundry-runtime-and-environment, tutorial>free-tier]
 primary_tag: programming-tool>sapui5
 author_name: Nico Schoenteich
 author_profile: https://github.com/nicoschoenteich

--- a/tutorials/cp-cf-sapui5-local-setup/cp-cf-sapui5-local-setup.md
+++ b/tutorials/cp-cf-sapui5-local-setup/cp-cf-sapui5-local-setup.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 5
-tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-environment, tutorial>free-tier]
+tags: [ tutorial>beginner, software-product>sap-btp--cloud-foundry-runtime-and-environment, tutorial>free-tier]
 primary_tag: programming-tool>sapui5
 author_name: Nico Schoenteich
 author_profile: https://github.com/nicoschoenteich

--- a/tutorials/hana-clients-cf/hana-clients-cf.md
+++ b/tutorials/hana-clients-cf/hana-clients-cf.md
@@ -4,7 +4,7 @@ author_name: Dan van Leeuwen
 author_profile: https://github.com/danielva
 auto_validation: true
 time: 15
-tags: [ tutorial>beginner, software-product-function>sap-hana-cloud--sap-hana-database, software-product>sap-hana, software-product>sap-hana--express-edition, programming-tool>node-js, software-product>sap-btp--cloud-foundry-environment, software-product>sap-business-technology-platform, software-product>sap-connectivity-service]
+tags: [ tutorial>beginner, software-product-function>sap-hana-cloud--sap-hana-database, software-product>sap-hana, software-product>sap-hana--express-edition, programming-tool>node-js, software-product>sap-btp--cloud-foundry-runtime-and-environment, software-product>sap-business-technology-platform, software-product>sap-connectivity-service]
 primary_tag: software-product>sap-hana-cloud
 ---
 

--- a/tutorials/hana-cloud-cap-deploy-mta/hana-cloud-cap-deploy-mta.md
+++ b/tutorials/hana-cloud-cap-deploy-mta/hana-cloud-cap-deploy-mta.md
@@ -1,7 +1,7 @@
 ---
 parser: v2
 time: 20
-tags: [ tutorial>intermediate, products>sap-hana, products>sap-business-application-studio, software-product-function>sap-cloud-application-programming-model, products>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>intermediate, products>sap-hana, products>sap-business-application-studio, software-product-function>sap-cloud-application-programming-model, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: products>sap-hana-cloud
 ---
 

--- a/tutorials/opps-advanced-scenario-additional-bonus/opps-advanced-scenario-additional-bonus.md
+++ b/tutorials/opps-advanced-scenario-additional-bonus/opps-advanced-scenario-additional-bonus.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 20
-tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, products>sap-btp--cloud-foundry-environment]
+tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: products>sap-business-technology-platform
 ---
 

--- a/tutorials/opps-advanced-scenario-coupon-loyalty-points/opps-advanced-scenario-coupon-loyalty-points.md
+++ b/tutorials/opps-advanced-scenario-coupon-loyalty-points/opps-advanced-scenario-coupon-loyalty-points.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 10
-tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, products>sap-btp--cloud-foundry-environment]
+tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: products>sap-business-technology-platform
 ---
 

--- a/tutorials/opps-advanced-scenario-mixandmatch/opps-advanced-scenario-mixandmatch.md
+++ b/tutorials/opps-advanced-scenario-mixandmatch/opps-advanced-scenario-mixandmatch.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 20
-tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, products>sap-btp--cloud-foundry-environment]
+tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: products>sap-business-technology-platform
 ---
 

--- a/tutorials/opps-advanced-scenario-singlecode-coupon-create/opps-advanced-scenario-singlecode-coupon-create.md
+++ b/tutorials/opps-advanced-scenario-singlecode-coupon-create/opps-advanced-scenario-singlecode-coupon-create.md
@@ -4,7 +4,7 @@ author_profile: https://github.com/BastLena
 keywords: tutorial
 auto_validation: true
 time: 10
-tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, products>sap-btp--cloud-foundry-environment]
+tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: products>sap-business-technology-platform
 parser: v2
 ---

--- a/tutorials/opps-advanced-scenario-singlecode-coupon-redeem/opps-advanced-scenario-singlecode-coupon-redeem.md
+++ b/tutorials/opps-advanced-scenario-singlecode-coupon-redeem/opps-advanced-scenario-singlecode-coupon-redeem.md
@@ -4,7 +4,7 @@ author_profile: https://github.com/BastLena
 keywords: tutorial
 auto_validation: true
 time: 30
-tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, products>sap-btp--cloud-foundry-environment]
+tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: products>sap-business-technology-platform
 parser: v2
 ---

--- a/tutorials/opps-advanced-scenario-singlecode-coupon-ui/opps-advanced-scenario-singlecode-coupon-ui.md
+++ b/tutorials/opps-advanced-scenario-singlecode-coupon-ui/opps-advanced-scenario-singlecode-coupon-ui.md
@@ -4,7 +4,7 @@ author_profile: https://github.com/BastLena
 keywords: tutorial
 auto_validation: true
 time: 30
-tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, products>sap-btp--cloud-foundry-environment]
+tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: products>sap-business-technology-platform
 parser: v2
 ---

--- a/tutorials/opps-advanced-scenario-transactional/opps-advanced-scenario-transactional.md
+++ b/tutorials/opps-advanced-scenario-transactional/opps-advanced-scenario-transactional.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 10
-tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, products>sap-btp--cloud-foundry-environment]
+tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: products>sap-business-technology-platform
 ---
 

--- a/tutorials/opps-basic-scenario-coupon-management/opps-basic-scenario-coupon-management.md
+++ b/tutorials/opps-basic-scenario-coupon-management/opps-basic-scenario-coupon-management.md
@@ -4,7 +4,7 @@ author_name: Aathira P
 author_profile: https://github.com/Aathira-I553036
 auto_validation: true
 time: 20
-tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, products>sap-btp--cloud-foundry-environment]
+tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: products>sap-business-technology-platform
 ---
 

--- a/tutorials/opps-basic-scenario-redeem-multicode-coupon/opps-basic-scenario-reserve-and-redeem-multi-code-coupon.md
+++ b/tutorials/opps-basic-scenario-redeem-multicode-coupon/opps-basic-scenario-reserve-and-redeem-multi-code-coupon.md
@@ -4,7 +4,7 @@ author_name: Aathira P
 author_profile: https://github.com/Aathira-I553036
 auto_validation: true
 time: 20
-tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, products>sap-btp--cloud-foundry-environment]
+tags: [tutorial>advanced, topic>cloud, products>sap-business-technology-platform, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: products>sap-business-technology-platform
 ---
 

--- a/tutorials/opps-basic-scenario/opps-basic-scenario.md
+++ b/tutorials/opps-basic-scenario/opps-basic-scenario.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 time: 30
-tags: [ tutorial>beginner, topic>cloud, products>sap-business-technology-platform, products>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>beginner, topic>cloud, products>sap-business-technology-platform, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: products>sap-business-technology-platform
 ---
 

--- a/tutorials/opps-manual-setup/opps-manual-setup.md
+++ b/tutorials/opps-manual-setup/opps-manual-setup.md
@@ -4,7 +4,7 @@ author_name: Lena Bast
 author_profile: https://github.com/BastLena
 auto_validation: true
 time: 10
-tags: [ tutorial>beginner, topic>cloud, products>sap-business-technology-platform, products>sap-btp--cloud-foundry-environment]
+tags: [ tutorial>beginner, topic>cloud, products>sap-business-technology-platform, software-product>sap-btp--cloud-foundry-runtime-and-environment]
 primary_tag: products>sap-business-technology-platform
 ---
 

--- a/tutorials/sapui5-101-add-routing/sapui5-101-add-routing.md
+++ b/tutorials/sapui5-101-add-routing/sapui5-101-add-routing.md
@@ -2,7 +2,7 @@
 parser: v2
 auto_validation: true
 primary_tag: programming-tool>sapui5
-tags: [  tutorial>beginner, programming-tool>html5, programming-tool>sapui5, software-product>sap-btp--cloud-foundry-environment, software-product>sap-business-application-studio  ]
+tags: [  tutorial>beginner, programming-tool>html5, programming-tool>sapui5, software-product>sap-btp--cloud-foundry-runtime-and-environment, software-product>sap-business-application-studio  ]
 time: 20
 author_name: Nico Schoenteich
 author_profile: https://github.com/nicoschoenteich

--- a/tutorials/sapui5-101-deploy-application/sapui5-101-deploy-application.md
+++ b/tutorials/sapui5-101-deploy-application/sapui5-101-deploy-application.md
@@ -3,7 +3,7 @@ parser: v2
 auto_validation: true
 time: 25
 tags: [ tutorial>beginner, programming-tool>javascript, programming-tool>sapui5, programming-tool>html5, software-product>sap-business-technology-platform, software-product>sap-business-application-studio]
-primary_tag: software-product>sap-btp--cloud-foundry-environment
+primary_tag: software-product>sap-btp--cloud-foundry-runtime-and-environment
 author_name: Nico Schoenteich
 author_profile: https://github.com/nicoschoenteich
 ---


### PR DESCRIPTION
## Defect
34 tutorials carry the **stale** Cloud Foundry environment product tag `sap-btp--cloud-foundry-environment` (under both the legacy `products>` and the current `software-product>` prefixes). The product tag was renamed; this slug is no longer a recognized taxonomy value.

## Fix
Replace the stale slug (matched as a complete token only — bounded by `,`, `]`, whitespace, or end-of-line) with the canonical tag:
- `products>sap-btp--cloud-foundry-environment` → `software-product>sap-btp--cloud-foundry-runtime-and-environment`
- `software-product>sap-btp--cloud-foundry-environment` → `software-product>sap-btp--cloud-foundry-runtime-and-environment`

Applied on `tags:` and `primary_tag:` frontmatter lines only. The already-canonical `...-cloud-foundry-runtime-and-environment` tag is untouched. No duplicate tags were produced (no file already carried the canonical tag), and no body text was changed.

## Scope
**34 files** (each carried exactly one stale token).

## Context
Flagged by the new `tutorial-ci` frontmatter-unknown-tag check — a renamed product tag cleanup. Publishing/rebuild so the change takes effect on the live site is a separate maintainer step.