### PR TITLE
fix(tags): replace deprecated 'sap-cloud-platform' product tag with BTP (9 files)

### DIFF
--- a/tutorials/api-tools-postman-install/api-tools-postman-install.md
+++ b/tutorials/api-tools-postman-install/api-tools-postman-install.md
@@ -1,7 +1,7 @@
 ---
 parser: v2
 primary_tag: topic>cloud
-tags: [  tutorial>how-to, tutorial>beginner, topic>cloud, products>sap-api-management, products>sap-cloud-platform, products>sap-cloud-platform-for-the-cloud-foundry-environment]
+tags: [  tutorial>how-to, tutorial>beginner, topic>cloud, products>sap-api-management, software-product>sap-business-technology-platform, products>sap-cloud-platform-for-the-cloud-foundry-environment]
 time: 5
 ---
 

--- a/tutorials/sth-add-text-fiori-app/sth-add-text-fiori-app.md
+++ b/tutorials/sth-add-text-fiori-app/sth-add-text-fiori-app.md
@@ -3,7 +3,7 @@ parser: v2
 author_name: Fiona Murphy
 author_profile: https://github.com/MCMANUSF
 primary_tag: products>sap-translation-hub
-tags: [  tutorial>beginner, products>sap-translation-hub, products>sap-cloud-platform, programming-tool>sapui5 ]
+tags: [  tutorial>beginner, products>sap-translation-hub, software-product>sap-business-technology-platform, programming-tool>sapui5 ]
 ---
 
 # Replace hardcoded text in a sample Fiori app (Neo environment)

--- a/tutorials/webide-github-branching/webide-github-branching.md
+++ b/tutorials/webide-github-branching/webide-github-branching.md
@@ -1,7 +1,7 @@
 ---
 parser: v2
 primary_tag: products>sap-web-ide
-tags: [ tutorial>intermediate, topic>cloud, products>sap-hana, products>sap-web-ide, products>sap-cloud-platform, tutorial>license ]
+tags: [ tutorial>intermediate, topic>cloud, products>sap-hana, products>sap-web-ide, software-product>sap-business-technology-platform, tutorial>license ]
 time: 15
 ---
 

--- a/tutorials/webide-github-create-git-repo/webide-github-create-git-repo.md
+++ b/tutorials/webide-github-create-git-repo/webide-github-create-git-repo.md
@@ -1,7 +1,7 @@
 ---
 parser: v2
 primary_tag: products>sap-web-ide
-tags: [ tutorial>beginner, topic>cloud, products>sap-hana, products>sap-web-ide, products>sap-cloud-platform ]
+tags: [ tutorial>beginner, topic>cloud, products>sap-hana, products>sap-web-ide, software-product>sap-business-technology-platform ]
 time: 5
 ---
 

--- a/tutorials/webide-github-creating-org/webide-github-creating-org.md
+++ b/tutorials/webide-github-creating-org/webide-github-creating-org.md
@@ -1,7 +1,7 @@
 ---
 parser: v2
 primary_tag: products>sap-web-ide
-tags: [ tutorial>beginner, topic>cloud, products>sap-hana, products>sap-web-ide, products>sap-cloud-platform ]
+tags: [ tutorial>beginner, topic>cloud, products>sap-hana, products>sap-web-ide, software-product>sap-business-technology-platform ]
 time: 5
 ---
 

--- a/tutorials/webide-github-import-project/webide-github-import-project.md
+++ b/tutorials/webide-github-import-project/webide-github-import-project.md
@@ -1,7 +1,7 @@
 ---
 parser: v2
 primary_tag: products>sap-web-ide
-tags: [ tutorial>intermediate, topic>cloud, products>sap-hana, products>sap-web-ide, products>sap-cloud-platform, tutorial>license ]
+tags: [ tutorial>intermediate, topic>cloud, products>sap-hana, products>sap-web-ide, software-product>sap-business-technology-platform, tutorial>license ]
 time: 15
 ---
 

--- a/tutorials/webide-github-issues-milestones/webide-github-issues-milestones.md
+++ b/tutorials/webide-github-issues-milestones/webide-github-issues-milestones.md
@@ -1,7 +1,7 @@
 ---
 parser: v2
 primary_tag: products>sap-web-ide
-tags: [ tutorial>intermediate, topic>cloud, products>sap-hana, products>sap-web-ide, products>sap-cloud-platform ]
+tags: [ tutorial>intermediate, topic>cloud, products>sap-hana, products>sap-web-ide, software-product>sap-business-technology-platform ]
 time: 10
 ---
 

--- a/tutorials/webide-github-merge-pull-request/webide-github-merge-pull-request.md
+++ b/tutorials/webide-github-merge-pull-request/webide-github-merge-pull-request.md
@@ -1,7 +1,7 @@
 ---
 parser: v2
 primary_tag: products>sap-web-ide
-tags: [ tutorial>intermediate, topic>cloud, products>sap-hana, products>sap-web-ide, products>sap-cloud-platform, tutorial>license ]
+tags: [ tutorial>intermediate, topic>cloud, products>sap-hana, products>sap-web-ide, software-product>sap-business-technology-platform, tutorial>license ]
 time: 10
 ---
 

--- a/tutorials/webide-multi-cloud/webide-multi-cloud.md
+++ b/tutorials/webide-multi-cloud/webide-multi-cloud.md
@@ -4,7 +4,7 @@ primary_tag: products>sap-web-ide
 author_name: Thomas Jung
 author_profile: https://github.com/jung-thomas
 auto_validation: true
-tags: [  tutorial>beginner, products>sap-cloud-platform, products>sap-web-ide, tutorial>license]
+tags: [  tutorial>beginner, software-product>sap-business-technology-platform, products>sap-web-ide, tutorial>license]
 time: 10
 ---
 


### PR DESCRIPTION
## Defect
9 tutorials carry the **deprecated** `sap-cloud-platform` product tag (SAP Cloud Platform was renamed to SAP Business Technology Platform). The bare slug is no longer a recognized taxonomy value.

## Fix
Replace the bare deprecated slug (matched as a complete token only — bounded by `,`, `]`, whitespace, or end-of-line) with the canonical BTP tag:
- `products>sap-cloud-platform` → `software-product>sap-business-technology-platform`
- `software-product>sap-cloud-platform` → `software-product>sap-business-technology-platform`

Applied on `tags:`/`primary_tag:` frontmatter lines only. The following distinct longer/escaped slugs are deliberately **left untouched** (they are separate valid tags, not the bare deprecated one):
- `sap-cloud-platform-for-the-cloud-foundry-environment` (still present in `api-tools-postman-install`)
- `sap-cloud-platform-connectivity`
- `sap-cloud-platform\,-sap-hana-service`

No duplicate tags were produced (no file already carried the BTP tag) and no body text was changed.

## Scope
**9 files** (each carried exactly one bare deprecated token).

## Context
Flagged by the new `tutorial-ci` frontmatter-unknown-tag check — a renamed/deprecated product tag cleanup. Publishing/rebuild so the change takes effect on the live site is a separate maintainer step.